### PR TITLE
PAGI-155: Bugfix - Requesting nodes by non-existent type

### DIFF
--- a/src/js/graph/graph.js
+++ b/src/js/graph/graph.js
@@ -66,7 +66,7 @@ Graph.prototype.addNode = function(node, connectEdges) {
     // Create node type buckets.
     this._nodeTypes[node.getType()] = this._nodeTypes[node.getType()] || [];
     this._nodeTypes[node.getType()].push(node);
-       
+
     if (connectEdges) { this.connectEdges([node]); }
 };
 Graph.prototype.connectEdges = function(nodes) {
@@ -74,7 +74,7 @@ Graph.prototype.connectEdges = function(nodes) {
     (nodes || this._graphImpl.nodes()).forEach(function(nodeId) {
         var node = self._graphImpl.node(nodeId);
         node.getEdges().forEach(function(edge) {
-            self._graphImpl.setEdge(node.getId(), edge.getTargetId(), edge.getEdgeType()); 
+            self._graphImpl.setEdge(node.getId(), edge.getTargetId(), edge.getEdgeType());
         });
         // If node is a span container create edges to all it's children.
         // This allows children to quickly reference their parent nodes.
@@ -94,6 +94,7 @@ Graph.prototype.connectEdges = function(nodes) {
 Graph.prototype.getNodeById = function(nodeId) { return this._graphImpl.node(nodeId); };
 Graph.prototype.getNodeTypes = function() { return Object.keys(this._nodeTypes); };
 Graph.prototype.getNodesByType = function(nodeType) {
+    if (this._nodeTypes[nodeType] === undefined) { return []; }
     return this._nodeTypes[nodeType].map(function(node) {
         return node;
     });

--- a/test/graph/graph-traversal-mary-test.js
+++ b/test/graph/graph-traversal-mary-test.js
@@ -21,6 +21,9 @@ describe('Graph traversal for `mary` stream', function() {
         assert.equal(graph.getNodesByType('COREF').length, 6);
         assert.equal(graph.getNodesByType('SB').length, 5);
     });
+    it('should return an empty array if provided a node type that does not exist', function() {
+        assert(graph.getNodesByType('THIS_DOES_NOT_EXIST').length === 0);
+    });
     it('should return the correct node by id', function() {
         var node = graph.getNodeById('0');
         assert.equal(node.getProp('start'), 96);


### PR DESCRIPTION
Requesting nodes with a node type that does not exist in the graph will throw an error. Refactor to return an empty array.
