### PR TITLE
PAGI-154 added parsing for effective schemas

### DIFF
--- a/src/js/schema/xml.js
+++ b/src/js/schema/xml.js
@@ -55,6 +55,9 @@ function doParse(readableStream, locator) {
 			case "pagis":
 				schemaBuilder.withId(tag.attributes.id.value);
 				break;
+			case "effectivePagis":
+				schemaBuilder.withId(tag.attributes.id.value);
+				break;
 			case "extends":
 				var parentId = tag.attributes.id.value;
 				var p = callLocator(parentId, locator).then(function(schema) {
@@ -171,21 +174,11 @@ function doParse(readableStream, locator) {
 			textContent += text.toString();
 		}
 	});
-    streamParser.on('text', function(text) {
-        text = text.trim();
-        if (currentTag && currentTag.name === 'description' && text.length > 0) {
-            if (edgeSpecBuilder) {
-                edgeSpecBuilder.withDescription(text);
-            } else if (propSpecBuilder) {
-                propSpecBuilder.withDescription(text);
-            } else if (nodeBuilder) {
-                nodeBuilder.withDescription(text);
-            }
-        }
-    });
 	streamParser.on("closetag", function(tagName) {
 		switch(tagName) {
 			case "pagis":
+				break;
+			case "effectivePagis":
 				break;
 			case "nodeTypeExtension":
 				if (nodeBuilder)
@@ -231,7 +224,7 @@ function doParse(readableStream, locator) {
 				}
 				break;
 		}
-        valueType = null;
+    valueType = null;
 	});
 	streamParser.on("end", function() {
 		Q.allSettled(delegatePromises).then(function() {
@@ -245,8 +238,7 @@ function doParse(readableStream, locator) {
 		readableStream.unpipe(streamParser);
 		deferred.reject(err);
 	});
-	try
-	{
+	try {
 		readableStream.pipe(streamParser);
 	} catch (e) {
 		throw Error("Could not parse stream " + readableStream.id + "..." + e);

--- a/test/test-suite/schema/def/effectiveSchema.xml
+++ b/test/test-suite/schema/def/effectiveSchema.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<effectivePagis xmlns="http://pagi.org/schema" id="http://pagi.org/testSuite/effective">
+
+  <nodeType name="nt1" readableName="node type 1">
+    <description>The first node type.</description>
+  </nodeType>
+
+  <nodeType name="nt2" readableName="node type 2" />
+
+  <nodeType name="nt3" readableName="node type 3">
+      <stringProperty name="p1" readableName="property 1" minArity="1" maxArity="1">
+        <description>A simple string property.</description>
+      </stringProperty>
+  </nodeType>
+
+  <nodeType name="nt3e" readableName="node type 3e">
+    <edgeType name="e1" readableName="edge 1">
+      <description>The edge that links this to another doohicky.</description>
+      <targetNodeType name="nt3"/>
+    </edgeType>
+  </nodeType>
+
+</effectivePagis>

--- a/test/test-suite/schema/flat/effectiveSchema.txt
+++ b/test/test-suite/schema/flat/effectiveSchema.txt
@@ -1,0 +1,11 @@
+http://pagi.org/testSuite/effective
+
+NODETYPE nt1 node type 1 The first node type.
+
+NODETYPE nt2 node type 2
+
+NODETYPE nt3 node type 3
+PROP p1 property 1 1 1 STRING A simple string property.
+
+NODETYPE nt3e node type 3e
+EDGE e1 edge 1 0 UNBOUNDED 0 UNBOUNDED nt3 The edge that links this to another doohicky.

--- a/test/test-suite/schema/full.list
+++ b/test/test-suite/schema/full.list
@@ -1,5 +1,6 @@
 http://pagi.org/testSuite/allIdPatterns allIdPatternsSchema
 http://pagi.org/testSuite/allRestrictions allRestrictionsSchema
+http://pagi.org/testSuite/effective effectiveSchema
 http://pagi.org/testSuite/extTokCoref extTokCorefSchema
 http://pagi.org/testSuite/extTokFull extTokFullSchema
 http://pagi.org/testSuite/extTok extTokSchema


### PR DESCRIPTION
Overview:
Adds schema parsing for schemas returned from the TC effective schema endpoint, whose primary nodes are effectivePagis instead of pagis

Testing:
Ensure tests run and pass
