### PR TITLE
`get(Start|End)Index` now works for non span/span containers

### DIFF
--- a/src/js/graph/node.js
+++ b/src/js/graph/node.js
@@ -72,13 +72,12 @@ Node.prototype.getText = function() {
     if (!isSpan && !isSpanContainer) {
         throw Error("Calling `getText` on a Node that does not have the `span` or `spanContainer` trait.");
     }
-    return this._graph.getContent().slice(this.getStartIndex(), this.getEndIndex() + 1);
+    return this._graph.getContent().slice(this.getStartIndex(), this.getEndIndex());
 };
 Node.prototype._getIndex = function(isStart) {
     if (this.hasTraitSpan()) {
         var start = this.getProp('start');
-        // Remove one as (start + length) will always be one greater than the length.
-        return isStart ? start : start + this.getProp('length') - 1;
+        return isStart ? start : start + this.getProp('length');
     }
     if (this.hasTraitSpanContainer()) {
         return isStart ? this.getFirst().getStartIndex() : this.getLast().getEndIndex();
@@ -104,9 +103,11 @@ Node.prototype._getIndex = function(isStart) {
         return reduced;
     }
 };
+// The value returned is INclusive to the annotation.
 Node.prototype.getStartIndex = function() {
     return this._getIndex(true);
 };
+// The value returned is EXclusive to the annotation.
 Node.prototype.getEndIndex = function() {
     return this._getIndex();
 };

--- a/test/graph/graph-traversal-mary-test.js
+++ b/test/graph/graph-traversal-mary-test.js
@@ -89,7 +89,7 @@ describe('Graph traversal for `mary` stream', function() {
         });
         it('should return the proper end index', function() {
             var node = graph.getNodeById('68');
-            assert.equal(node.getEndIndex(), 105);
+            assert.equal(node.getEndIndex(), 106);
         });
     });
     describe('non-span/span-container node', function() {
@@ -101,7 +101,7 @@ describe('Graph traversal for `mary` stream', function() {
             assert.equal(node.getStartIndex(), 0);
         });
         it('should find an end index', function() {
-            assert.equal(node.getEndIndex(), 411);
+            assert.equal(node.getEndIndex(), 412);
         });
         it('should return -1 if it cannot find a start index', function() {
             // Not possible to test atm. All nodes boil down to a span.

--- a/test/graph/graph-traversal-mary-test.js
+++ b/test/graph/graph-traversal-mary-test.js
@@ -89,7 +89,25 @@ describe('Graph traversal for `mary` stream', function() {
         });
         it('should return the proper end index', function() {
             var node = graph.getNodeById('68');
-            assert.equal(node.getEndIndex(), 106);
+            assert.equal(node.getEndIndex(), 105);
+        });
+    });
+    describe('non-span/span-container node', function() {
+        var node;
+        beforeEach(function() {
+            node = graph.getNodeById('21');
+        });
+        it('should find a start index', function() {
+            assert.equal(node.getStartIndex(), 0);
+        });
+        it('should find an end index', function() {
+            assert.equal(node.getEndIndex(), 411);
+        });
+        it('should return -1 if it cannot find a start index', function() {
+            // Not possible to test atm. All nodes boil down to a span.
+        });
+        it('should return -1 if it cannot find an end index', function() {
+            // Not possible to test atm. All nodes boil down to a span.
         });
     });
 });


### PR DESCRIPTION
`getStartIndex` and `getEndIndex` now compute the start and end offsets of a node by walking all edges that are not of the same type. Then determining the lowest index for `start` and highest for `end`. If a start or end index cannot be determined `-1` should be the returned value.

AC: 

Ensure tests run.
