### PR TITLE
Feature/pagi 160 node prop structure

### DIFF
--- a/src/js/graph/node.js
+++ b/src/js/graph/node.js
@@ -30,10 +30,21 @@ Node.prototype.addProp = function(type, key, val) {
         default:
             throw Error("Unknown Node property type `" + type + "`.");
     }
-    this._properties[key] = { type: type, key: key, val: newVal };
+
+    if (Array.isArray(this._properties[key])) {
+        this._properties[key].push({ type: type, key: key, val: newVal });
+    } else {
+        this._properties[key] = [{ type: type, key: key, val: newVal }];
+    }
 };
 Node.prototype.getProp = function(key) {
-    return this._properties[key] && this._properties[key].val;
+    return this._properties[key] && this._properties[key].map(function(prop) {
+        return prop.val;
+    });
+};
+Node.prototype.getFirstProp = function(key) {
+    // convenience method for properties with known max arity of 1
+    return this._properties[key] && this._properties[key][0].val;
 };
 Node.prototype.getProps = function() {
     return JSON.parse(JSON.stringify(this._properties));
@@ -76,8 +87,8 @@ Node.prototype.getText = function() {
 };
 Node.prototype._getIndex = function(isStart) {
     if (this.hasTraitSpan()) {
-        var start = this.getProp('start');
-        return isStart ? start : start + this.getProp('length');
+        var start = this.getFirstProp('start');
+        return isStart ? start : start + this.getFirstProp('length');
     }
     if (this.hasTraitSpanContainer()) {
         return isStart ? this.getFirst().getStartIndex() : this.getLast().getEndIndex();

--- a/src/js/graph/serializers/graphSerializerXml.js
+++ b/src/js/graph/serializers/graphSerializerXml.js
@@ -28,8 +28,10 @@ GraphSerializerXml.prototype.serializeNode = function(node) {
     var lines = [TAB + '<node id="' + es(node.getId()) + '" type="' + es(node.getType()) + '">'];
     var props = node.getProps();
     Object.keys(props).forEach(function(key) {
-        var prop = props[key];
-        lines.push(TAB+TAB + '<' + nodePropMap[prop.type] + 'Prop v="' + es(prop.val) + '" k="' + es(prop.key) + '"/>');
+        var propVals = props[key];
+        propVals.forEach(function(prop) {
+            lines.push(TAB+TAB + '<' + nodePropMap[prop.type] + 'Prop v="' + es(prop.val) + '" k="' + es(prop.key) + '"/>');
+        });
     });
     node.getEdges().forEach(function(edge) {
         lines.push(TAB+TAB + '<edge toType="' + es(edge.getTargetType()) + '" to="' + es(edge.getTargetId()) + '" type="' + es(edge.getEdgeType()) + '"/>');

--- a/test/graph/graph-traversal-mary-test.js
+++ b/test/graph/graph-traversal-mary-test.js
@@ -26,9 +26,9 @@ describe('Graph traversal for `mary` stream', function() {
     });
     it('should return the correct node by id', function() {
         var node = graph.getNodeById('0');
-        assert.equal(node.getProp('start'), 96);
-        assert.equal(node.getProp('length'), 4);
-        assert.equal(node.getProp('pos'), 'JJ');
+        assert.equal(node.getFirstProp('start'), 96);
+        assert.equal(node.getFirstProp('length'), 4);
+        assert.equal(node.getFirstProp('pos'), 'JJ');
     });
     describe('span trait', function() {
         it('node should return the correct text', function() {

--- a/test/graph/graphSerializer-test.js
+++ b/test/graph/graphSerializer-test.js
@@ -26,13 +26,13 @@ describe('GraphSerializer', function() {
             if (stream.name === 'testDoc1') {
                 it('does not support node features', function() {
                     GraphParser.parse(stream.getXmlStream()).fail(function(err) {
-                        assert.throws(err, /Pagi.js does not support node features/);    
+                        assert.throws(err, /Pagi.js does not support node features/);
                     });
                 });
             } else if (stream.name === 'testDoc2') {
                 it('does not support nested node properties', function() {
                     GraphParser.parse(stream.getXmlStream()).fail(function(err) {
-                        assert.throws(err, /Pagi.js does not support nested node property values/);    
+                        assert.throws(err, /Pagi.js does not support nested node property values/);
                     });
                 });
             } else {
@@ -40,7 +40,7 @@ describe('GraphSerializer', function() {
                 beforeEach(function(done) {
                     GraphParser.parse(stream.getXmlStream()).then(function(aGraph) {
                         graph = aGraph; done();
-                    });
+                    }, console.error);
                 });
                 it('matches the xml file', function() {
                     var preSerialized = GraphSerializer.serialize(graph);

--- a/test/test-suite/schema/def/extTokParticipantSchema.xml
+++ b/test/test-suite/schema/def/extTokParticipantSchema.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pagis xmlns="http://pagi.org/schema" id="http://pagi.org/testSuite/extTokParticipant">
+	<extends id="http://pagi.org/testSuite/extTok"/>
+
+  <nodeType name="PARTICIPANT">
+    <stringProperty name="alias" minArity="0" maxArity="unbounded"/>
+    <stringProperty name="name" minArity="0" maxArity="1"/>
+    <stringProperty name="phone-number" minArity="0" maxArity="unbounded"/>
+    <enumProperty name="type" minArity="1" maxArity="unbounded">
+      <item name="author"/>
+      <item name="copied"/>
+    </enumProperty>
+  </nodeType>
+</pagis>

--- a/test/test-suite/schema/flat/extTokParticipantSchema.txt
+++ b/test/test-suite/schema/flat/extTokParticipantSchema.txt
@@ -1,0 +1,19 @@
+http://pagi.org/testSuite/extTokParticipant
+EXTENDS http://pagi.org/testSuite/extTok
+
+NODETYPE PARTICIPANT
+PROP alias 0 UNBOUNDED STRING
+PROP name 0 1 STRING
+PROP phone-number 0 UNBOUNDED STRING
+PROP type 1 UNBOUNDED STRING author copied
+
+NODETYPE SB SEQUENCE SPAN_CONTAINER TOK
+EDGE first 1 1 0 UNBOUNDED TOK
+EDGE last 1 1 0 UNBOUNDED TOK
+EDGE next 0 1 0 UNBOUNDED SB
+
+NODETYPE TOK SEQUENCE SPAN
+PROP length 1 1 INTEGER 0 2147483647
+PROP pos 0 UNBOUNDED STRING These pos tags are taken from Penn Treebank - here: https://www.ling.upenn.edu/courses/Fall_2003/ling001/penn_treebank_pos.html " ' , CC CD DT EX FW IN JJ JJR JJS LS MD NN NNP NNPS NNS P2S P3S PDT POS PRP PRP$ RB RBR RBS RP SYM TO UH VB VBD VBG VBN VBP VBZ WDT WP WP$ WRB
+PROP start 1 1 INTEGER 0 2147483647
+EDGE next 0 1 0 UNBOUNDED TOK

--- a/test/test-suite/schema/full.list
+++ b/test/test-suite/schema/full.list
@@ -3,6 +3,7 @@ http://pagi.org/testSuite/allRestrictions allRestrictionsSchema
 http://pagi.org/testSuite/effective effectiveSchema
 http://pagi.org/testSuite/extTokCoref extTokCorefSchema
 http://pagi.org/testSuite/extTokFull extTokFullSchema
+http://pagi.org/testSuite/extTokParticipant extTokParticipantSchema
 http://pagi.org/testSuite/extTok extTokSchema
 http://pagi.org/testSuite/readableNames readableNamesSchema
 http://pagi.org/testSuite/simpleProps simplePropsSchema

--- a/test/test-suite/stream/full.list
+++ b/test/test-suite/stream/full.list
@@ -1,6 +1,7 @@
 crooked
 diddle
 mary
+participant
 peter
 sixpence
 testDoc1

--- a/test/test-suite/stream/xml/participant.xml
+++ b/test/test-suite/stream/xml/participant.xml
@@ -1,0 +1,686 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://pagi.org/stream" id="mary" version="2.0"><schema uri="http://pagi.org/testSuite/extTokParticipant"></schema>
+	<asSpan nodeType="TOK"></asSpan>
+	<asSequence nodeType="TOK"></asSequence>
+	<asSequence nodeType="SB"></asSequence>
+	<asSpanContainer spanType="TOK" nodeType="SB"></asSpanContainer>
+	<content contentType="text/plain">MARY had a little lamb with fleece as white as snow,
+And everywhere that Mary went the lamb was sure to go.
+It followed her to school one day, that was against the rule.
+It made the children laugh and play, to see a lamb at school.
+
+And so the teacher turned it out, but still it lingered near,
+And waited patiently about till Mary did appear.
+"Why does the lamb love Mary so," the eager children cry,
+"Why, Mary loves the lamb, you know!" the teacher did reply.
+
+</content>
+
+	<node id="0" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="96" k="start"></intProp>
+		<strProp v="JJ" k="pos"></strProp>
+		<edge toType="TOK" to="1" type="next"></edge>
+	</node>
+	<node id="2" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="358" k="start"></intProp>
+		<strProp v="NN" k="pos"></strProp>
+		<edge toType="TOK" to="3" type="next"></edge>
+	</node>
+	<node id="4" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="201" k="start"></intProp>
+		<strProp v="VB" k="pos"></strProp>
+		<edge toType="TOK" to="5" type="next"></edge>
+	</node>
+	<node id="1" type="TOK">
+		<intProp v="2" k="length"></intProp>
+		<intProp v="101" k="start"></intProp>
+		<strProp v="IN" k="pos"></strProp>
+		<edge toType="TOK" to="6" type="next"></edge>
+	</node>
+	<node id="6" type="TOK">
+		<intProp v="2" k="length"></intProp>
+		<intProp v="104" k="start"></intProp>
+		<strProp v="VB" k="pos"></strProp>
+	</node>
+	<node id="7" type="COREF">
+		<strProp v="school" k="name"></strProp>
+		<edge toType="TOK" to="8" type="member"></edge>
+		<edge toType="TOK" to="9" type="member"></edge>
+	</node>
+	<node id="10" type="COREF">
+		<strProp v="children" k="name"></strProp>
+		<edge toType="TOK" to="11" type="member"></edge>
+		<edge toType="TOK" to="12" type="member"></edge>
+	</node>
+	<node id="13" type="COREF">
+		<strProp v="lamb" k="name"></strProp>
+		<edge toType="TOK" to="14" type="member"></edge>
+		<edge toType="TOK" to="2" type="member"></edge>
+		<edge toType="TOK" to="15" type="member"></edge>
+		<edge toType="TOK" to="16" type="member"></edge>
+		<edge toType="TOK" to="17" type="member"></edge>
+	</node>
+	<node id="18" type="COREF">
+		<strProp v="teacher" k="name"></strProp>
+		<edge toType="TOK" to="19" type="member"></edge>
+		<edge toType="TOK" to="20" type="member"></edge>
+	</node>
+	<node id="21" type="COREF">
+		<strProp v="mary" k="name"></strProp>
+		<edge toType="TOK" to="22" type="member"></edge>
+		<edge toType="TOK" to="23" type="member"></edge>
+		<edge toType="TOK" to="24" type="member"></edge>
+		<edge toType="TOK" to="25" type="member"></edge>
+		<edge toType="TOK" to="26" type="member"></edge>
+	</node>
+	<node id="27" type="TOK">
+		<intProp v="5" k="length"></intProp>
+		<intProp v="456" k="start"></intProp>
+		<strProp v="NN" k="pos"></strProp>
+	</node>
+	<node id="28" type="TOK">
+		<intProp v="2" k="length"></intProp>
+		<intProp v="170" k="start"></intProp>
+		<strProp v="P3S" k="pos"></strProp>
+		<edge toType="TOK" to="29" type="next"></edge>
+	</node>
+	<node id="30" type="COREF">
+		<strProp v="that" k="name"></strProp>
+		<edge toType="TOK" to="31" type="member"></edge>
+		<edge toType="TOK" to="32" type="member"></edge>
+	</node>
+	<node id="29" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="173" k="start"></intProp>
+		<strProp v="VBD" k="pos"></strProp>
+		<edge toType="TOK" to="33" type="next"></edge>
+	</node>
+	<node id="34" type="TOK">
+		<intProp v="5" k="length"></intProp>
+		<intProp v="316" k="start"></intProp>
+		<strProp v="RB" k="pos"></strProp>
+		<edge toType="TOK" to="35" type="next"></edge>
+	</node>
+	<node id="36" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="452" k="start"></intProp>
+		<strProp v="VBD" k="pos"></strProp>
+		<edge toType="TOK" to="27" type="next"></edge>
+	</node>
+	<node id="14" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="423" k="start"></intProp>
+		<strProp v="NN" k="pos"></strProp>
+		<edge toType="TOK" to="37" type="next"></edge>
+	</node>
+	<node id="38" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="138" k="start"></intProp>
+		<strProp v="NN" k="pos"></strProp>
+		<edge toType="TOK" to="39" type="next"></edge>
+	</node>
+	<node id="40" type="TOK">
+		<intProp v="1" k="length"></intProp>
+		<intProp v="406" k="start"></intProp>
+		<strProp v="," k="pos"></strProp>
+		<edge toType="TOK" to="23" type="next"></edge>
+	</node>
+	<node id="19" type="TOK">
+		<intProp v="7" k="length"></intProp>
+		<intProp v="444" k="start"></intProp>
+		<strProp v="NN" k="pos"></strProp>
+		<edge toType="TOK" to="36" type="next"></edge>
+	</node>
+	<node id="23" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="408" k="start"></intProp>
+		<strProp v="NNP" k="pos"></strProp>
+		<edge toType="TOK" to="41" type="next"></edge>
+	</node>
+	<node id="42" type="TOK">
+		<intProp v="2" k="length"></intProp>
+		<intProp v="207" k="start"></intProp>
+		<strProp v="IN" k="pos"></strProp>
+		<edge toType="TOK" to="43" type="next"></edge>
+	</node>
+	<node id="44" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="120" k="start"></intProp>
+		<strProp v="P3S" k="pos"></strProp>
+		<edge toType="TOK" to="45" type="next"></edge>
+	</node>
+	<node id="46" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="47" k="start"></intProp>
+		<strProp v="NN" k="pos"></strProp>
+		<edge toType="TOK" to="47" type="next"></edge>
+	</node>
+	<node id="48" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="240" k="start"></intProp>
+		<strProp v="DT" k="pos"></strProp>
+		<edge toType="TOK" to="20" type="next"></edge>
+	</node>
+	<node id="49" type="TOK">
+		<intProp v="2" k="length"></intProp>
+		<intProp v="277" k="start"></intProp>
+		<strProp v="P3S" k="pos"></strProp>
+		<edge toType="TOK" to="50" type="next"></edge>
+	</node>
+	<node id="51" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="78" k="start"></intProp>
+		<strProp v="VBD" k="pos"></strProp>
+		<edge toType="TOK" to="52" type="next"></edge>
+	</node>
+	<node id="53" type="TOK">
+		<intProp v="1" k="length"></intProp>
+		<intProp v="9" k="start"></intProp>
+		<strProp v="DT" k="pos"></strProp>
+		<edge toType="TOK" to="54" type="next"></edge>
+	</node>
+	<node id="33" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="178" k="start"></intProp>
+		<strProp v="DT" k="pos"></strProp>
+		<edge toType="TOK" to="12" type="next"></edge>
+	</node>
+	<node id="55" type="TOK">
+		<intProp v="2" k="length"></intProp>
+		<intProp v="44" k="start"></intProp>
+		<strProp v="IN" k="pos"></strProp>
+		<edge toType="TOK" to="46" type="next"></edge>
+	</node>
+	<node id="56" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="23" k="start"></intProp>
+		<strProp v="IN" k="pos"></strProp>
+		<edge toType="TOK" to="57" type="next"></edge>
+	</node>
+	<node id="58" type="TOK">
+		<intProp v="2" k="length"></intProp>
+		<intProp v="221" k="start"></intProp>
+		<strProp v="IN" k="pos"></strProp>
+		<edge toType="TOK" to="8" type="next"></edge>
+	</node>
+	<node id="59" type="TOK">
+		<intProp v="2" k="length"></intProp>
+		<intProp v="35" k="start"></intProp>
+		<strProp v="IN" k="pos"></strProp>
+		<edge toType="TOK" to="60" type="next"></edge>
+	</node>
+	<node id="41" type="TOK">
+		<intProp v="5" k="length"></intProp>
+		<intProp v="413" k="start"></intProp>
+		<strProp v="VBZ" k="pos"></strProp>
+		<edge toType="TOK" to="61" type="next"></edge>
+	</node>
+	<node id="62" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="345" k="start"></intProp>
+		<strProp v="RB" k="pos"></strProp>
+		<edge toType="TOK" to="63" type="next"></edge>
+	</node>
+	<node id="64" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="164" k="start"></intProp>
+		<strProp v="NN" k="pos"></strProp>
+	</node>
+	<node id="65" type="TOK">
+		<intProp v="6" k="length"></intProp>
+		<intProp v="252" k="start"></intProp>
+		<strProp v="VBD" k="pos"></strProp>
+		<edge toType="TOK" to="66" type="next"></edge>
+	</node>
+	<node id="12" type="TOK">
+		<intProp v="8" k="length"></intProp>
+		<intProp v="182" k="start"></intProp>
+		<strProp v="NNS" k="pos"></strProp>
+		<edge toType="TOK" to="67" type="next"></edge>
+	</node>
+	<node id="68" type="SB">
+		<edge toType="TOK" to="24" type="first"></edge>
+		<edge toType="SB" to="69" type="next"></edge>
+		<edge toType="TOK" to="6" type="last"></edge>
+	</node>
+	<node id="8" type="TOK">
+		<intProp v="6" k="length"></intProp>
+		<intProp v="224" k="start"></intProp>
+		<strProp v="NN" k="pos"></strProp>
+	</node>
+	<node id="70" type="SB">
+		<edge toType="TOK" to="8" type="last"></edge>
+		<edge toType="SB" to="71" type="next"></edge>
+		<edge toType="TOK" to="28" type="first"></edge>
+	</node>
+	<node id="69" type="SB">
+		<edge toType="TOK" to="72" type="first"></edge>
+		<edge toType="SB" to="70" type="next"></edge>
+		<edge toType="TOK" to="64" type="last"></edge>
+	</node>
+	<node id="73" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="262" k="start"></intProp>
+		<strProp v="IN" k="pos"></strProp>
+		<edge toType="TOK" to="74" type="next"></edge>
+	</node>
+	<node id="75" type="SB">
+		<edge toType="TOK" to="27" type="last"></edge>
+		<edge toType="TOK" to="76" type="first"></edge>
+	</node>
+	<node id="71" type="SB">
+		<edge toType="TOK" to="77" type="first"></edge>
+		<edge toType="TOK" to="78" type="last"></edge>
+		<edge toType="SB" to="75" type="next"></edge>
+	</node>
+	<node id="79" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="92" k="start"></intProp>
+		<strProp v="VBD" k="pos"></strProp>
+		<edge toType="TOK" to="0" type="next"></edge>
+	</node>
+	<node id="80" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="197" k="start"></intProp>
+		<strProp v="CC" k="pos"></strProp>
+		<edge toType="TOK" to="4" type="next"></edge>
+	</node>
+	<node id="54" type="TOK">
+		<intProp v="6" k="length"></intProp>
+		<intProp v="11" k="start"></intProp>
+		<strProp v="JJ" k="pos"></strProp>
+		<edge toType="TOK" to="15" type="next"></edge>
+	</node>
+	<node id="81" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="134" k="start"></intProp>
+		<strProp v="CD" k="pos"></strProp>
+		<edge toType="TOK" to="38" type="next"></edge>
+	</node>
+	<node id="82" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="440" k="start"></intProp>
+		<strProp v="DT" k="pos"></strProp>
+		<edge toType="TOK" to="19" type="next"></edge>
+	</node>
+	<node id="24" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="0" k="start"></intProp>
+		<strProp v="NNP" k="pos"></strProp>
+		<edge toType="TOK" to="83" type="next"></edge>
+	</node>
+	<node id="84" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="397" k="start"></intProp>
+		<strProp v="VB" k="pos"></strProp>
+		<edge toType="TOK" to="85" type="next"></edge>
+	</node>
+	<node id="45" type="TOK">
+		<intProp v="2" k="length"></intProp>
+		<intProp v="124" k="start"></intProp>
+		<strProp v="IN" k="pos"></strProp>
+		<edge toType="TOK" to="9" type="next"></edge>
+	</node>
+	<node id="86" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="160" k="start"></intProp>
+		<strProp v="DT" k="pos"></strProp>
+		<edge toType="TOK" to="64" type="next"></edge>
+	</node>
+	<node id="87" type="TOK">
+		<intProp v="7" k="length"></intProp>
+		<intProp v="152" k="start"></intProp>
+		<strProp v="IN" k="pos"></strProp>
+		<edge toType="TOK" to="86" type="next"></edge>
+	</node>
+	<node id="3" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="363" k="start"></intProp>
+		<strProp v="NN" k="pos"></strProp>
+		<edge toType="TOK" to="25" type="next"></edge>
+	</node>
+	<node id="88" type="TOK">
+		<intProp v="1" k="length"></intProp>
+		<intProp v="214" k="start"></intProp>
+		<strProp v="DT" k="pos"></strProp>
+		<edge toType="TOK" to="17" type="next"></edge>
+	</node>
+	<node id="20" type="TOK">
+		<intProp v="7" k="length"></intProp>
+		<intProp v="244" k="start"></intProp>
+		<strProp v="NN" k="pos"></strProp>
+		<edge toType="TOK" to="65" type="next"></edge>
+	</node>
+	<node id="17" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="216" k="start"></intProp>
+		<strProp v="NN" k="pos"></strProp>
+		<edge toType="TOK" to="58" type="next"></edge>
+	</node>
+	<node id="89" type="TOK">
+		<intProp v="5" k="length"></intProp>
+		<intProp v="382" k="start"></intProp>
+		<strProp v="JJ" k="pos"></strProp>
+		<edge toType="TOK" to="11" type="next"></edge>
+	</node>
+	<node id="90" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="289" k="start"></intProp>
+		<strProp v="IN" k="pos"></strProp>
+		<edge toType="TOK" to="91" type="next"></edge>
+	</node>
+	<node id="67" type="TOK">
+		<intProp v="5" k="length"></intProp>
+		<intProp v="191" k="start"></intProp>
+		<strProp v="VB" k="pos"></strProp>
+		<edge toType="TOK" to="80" type="next"></edge>
+	</node>
+	<node id="92" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="295" k="start"></intProp>
+		<strProp v="CC" k="pos"></strProp>
+		<edge toType="TOK" to="93" type="next"></edge>
+	</node>
+	<node id="22" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="327" k="start"></intProp>
+		<strProp v="NNP" k="pos"></strProp>
+		<edge toType="TOK" to="94" type="next"></edge>
+	</node>
+	<node id="26" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="73" k="start"></intProp>
+		<strProp v="NNP" k="pos"></strProp>
+		<edge toType="TOK" to="51" type="next"></edge>
+	</node>
+	<node id="95" type="TOK">
+		<intProp v="9" k="length"></intProp>
+		<intProp v="306" k="start"></intProp>
+		<strProp v="RB" k="pos"></strProp>
+		<edge toType="TOK" to="34" type="next"></edge>
+	</node>
+	<node id="96" type="TOK">
+		<intProp v="1" k="length"></intProp>
+		<intProp v="402" k="start"></intProp>
+		<strProp v="&quot;" k="pos"></strProp>
+		<edge toType="TOK" to="97" type="next"></edge>
+	</node>
+	<node id="43" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="210" k="start"></intProp>
+		<strProp v="VB" k="pos"></strProp>
+		<edge toType="TOK" to="88" type="next"></edge>
+	</node>
+	<node id="66" type="TOK">
+		<intProp v="2" k="length"></intProp>
+		<intProp v="259" k="start"></intProp>
+		<strProp v="P3S" k="pos"></strProp>
+		<edge toType="TOK" to="73" type="next"></edge>
+	</node>
+	<node id="63" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="349" k="start"></intProp>
+		<strProp v="VBZ" k="pos"></strProp>
+		<edge toType="TOK" to="98" type="next"></edge>
+	</node>
+	<node id="50" type="TOK">
+		<intProp v="8" k="length"></intProp>
+		<intProp v="280" k="start"></intProp>
+		<strProp v="VBD" k="pos"></strProp>
+		<edge toType="TOK" to="90" type="next"></edge>
+	</node>
+	<node id="91" type="TOK">
+		<intProp v="1" k="length"></intProp>
+		<intProp v="293" k="start"></intProp>
+		<strProp v="," k="pos"></strProp>
+		<edge toType="TOK" to="92" type="next"></edge>
+	</node>
+	<node id="57" type="TOK">
+		<intProp v="6" k="length"></intProp>
+		<intProp v="28" k="start"></intProp>
+		<strProp v="NN" k="pos"></strProp>
+		<edge toType="TOK" to="59" type="next"></edge>
+	</node>
+	<node id="99" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="429" k="start"></intProp>
+		<strProp v="P2S" k="pos"></strProp>
+		<edge toType="TOK" to="100" type="next"></edge>
+	</node>
+	<node id="15" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="18" k="start"></intProp>
+		<strProp v="NN" k="pos"></strProp>
+		<edge toType="TOK" to="56" type="next"></edge>
+	</node>
+	<node id="76" type="TOK">
+		<intProp v="1" k="length"></intProp>
+		<intProp v="344" k="start"></intProp>
+		<strProp v="&quot;" k="pos"></strProp>
+		<edge toType="TOK" to="62" type="next"></edge>
+	</node>
+	<node id="61" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="419" k="start"></intProp>
+		<strProp v="DT" k="pos"></strProp>
+		<edge toType="TOK" to="14" type="next"></edge>
+	</node>
+	<node id="37" type="TOK">
+		<intProp v="1" k="length"></intProp>
+		<intProp v="427" k="start"></intProp>
+		<strProp v="," k="pos"></strProp>
+		<edge toType="TOK" to="99" type="next"></edge>
+	</node>
+	<node id="35" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="322" k="start"></intProp>
+		<strProp v="IN" k="pos"></strProp>
+		<edge toType="TOK" to="22" type="next"></edge>
+	</node>
+	<node id="101" type="TOK">
+		<intProp v="10" k="length"></intProp>
+		<intProp v="57" k="start"></intProp>
+		<strProp v="RB" k="pos"></strProp>
+		<edge toType="TOK" to="32" type="next"></edge>
+	</node>
+	<node id="102" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="378" k="start"></intProp>
+		<strProp v="DT" k="pos"></strProp>
+		<edge toType="TOK" to="89" type="next"></edge>
+	</node>
+	<node id="9" type="TOK">
+		<intProp v="6" k="length"></intProp>
+		<intProp v="127" k="start"></intProp>
+		<strProp v="NN" k="pos"></strProp>
+		<edge toType="TOK" to="81" type="next"></edge>
+	</node>
+	<node id="60" type="TOK">
+		<intProp v="5" k="length"></intProp>
+		<intProp v="38" k="start"></intProp>
+		<strProp v="JJ" k="pos"></strProp>
+		<edge toType="TOK" to="55" type="next"></edge>
+	</node>
+	<node id="93" type="TOK">
+		<intProp v="6" k="length"></intProp>
+		<intProp v="299" k="start"></intProp>
+		<strProp v="VBD" k="pos"></strProp>
+		<edge toType="TOK" to="95" type="next"></edge>
+	</node>
+	<node id="103" type="TOK">
+		<intProp v="2" k="length"></intProp>
+		<intProp v="437" k="start"></intProp>
+		<strProp v="NN" k="pos"></strProp>
+		<edge toType="TOK" to="82" type="next"></edge>
+	</node>
+	<node id="104" type="TOK">
+		<intProp v="8" k="length"></intProp>
+		<intProp v="111" k="start"></intProp>
+		<strProp v="VBD" k="pos"></strProp>
+		<edge toType="TOK" to="44" type="next"></edge>
+	</node>
+	<node id="105" type="TOK">
+		<intProp v="5" k="length"></intProp>
+		<intProp v="271" k="start"></intProp>
+		<strProp v="RB" k="pos"></strProp>
+		<edge toType="TOK" to="49" type="next"></edge>
+	</node>
+	<node id="5" type="TOK">
+		<intProp v="1" k="length"></intProp>
+		<intProp v="205" k="start"></intProp>
+		<strProp v="," k="pos"></strProp>
+		<edge toType="TOK" to="42" type="next"></edge>
+	</node>
+	<node id="98" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="354" k="start"></intProp>
+		<strProp v="DT" k="pos"></strProp>
+		<edge toType="TOK" to="2" type="next"></edge>
+	</node>
+	<node id="106" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="267" k="start"></intProp>
+		<strProp v="CC" k="pos"></strProp>
+		<edge toType="TOK" to="105" type="next"></edge>
+	</node>
+	<node id="107" type="TOK">
+		<intProp v="2" k="length"></intProp>
+		<intProp v="237" k="start"></intProp>
+		<strProp v="RB" k="pos"></strProp>
+		<edge toType="TOK" to="48" type="next"></edge>
+	</node>
+	<node id="83" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="5" k="start"></intProp>
+		<strProp v="VBD" k="pos"></strProp>
+		<edge toType="TOK" to="53" type="next"></edge>
+	</node>
+	<node id="72" type="TOK">
+		<intProp v="2" k="length"></intProp>
+		<intProp v="108" k="start"></intProp>
+		<strProp v="P3S" k="pos"></strProp>
+		<edge toType="TOK" to="104" type="next"></edge>
+	</node>
+	<node id="100" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="433" k="start"></intProp>
+		<strProp v="VB" k="pos"></strProp>
+		<edge toType="TOK" to="103" type="next"></edge>
+	</node>
+	<node id="11" type="TOK">
+		<intProp v="8" k="length"></intProp>
+		<intProp v="388" k="start"></intProp>
+		<strProp v="NNS" k="pos"></strProp>
+		<edge toType="TOK" to="84" type="next"></edge>
+	</node>
+	<node id="108" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="53" k="start"></intProp>
+		<strProp v="CC" k="pos"></strProp>
+		<edge toType="TOK" to="101" type="next"></edge>
+	</node>
+	<node id="32" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="68" k="start"></intProp>
+		<strProp v="P3S" k="pos"></strProp>
+		<edge toType="TOK" to="26" type="next"></edge>
+	</node>
+	<node id="109" type="TOK">
+		<intProp v="2" k="length"></intProp>
+		<intProp v="375" k="start"></intProp>
+		<strProp v="NN" k="pos"></strProp>
+		<edge toType="TOK" to="102" type="next"></edge>
+	</node>
+	<node id="97" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="403" k="start"></intProp>
+		<strProp v="RB" k="pos"></strProp>
+		<edge toType="TOK" to="40" type="next"></edge>
+	</node>
+	<node id="77" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="233" k="start"></intProp>
+		<strProp v="CC" k="pos"></strProp>
+		<edge toType="TOK" to="107" type="next"></edge>
+	</node>
+	<node id="31" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="143" k="start"></intProp>
+		<strProp v="P3S" k="pos"></strProp>
+		<edge toType="TOK" to="110" type="next"></edge>
+	</node>
+	<node id="52" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="83" k="start"></intProp>
+		<strProp v="DT" k="pos"></strProp>
+		<edge toType="TOK" to="16" type="next"></edge>
+	</node>
+	<node id="94" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="332" k="start"></intProp>
+		<strProp v="VBD" k="pos"></strProp>
+		<edge toType="TOK" to="78" type="next"></edge>
+	</node>
+	<node id="85" type="TOK">
+		<intProp v="1" k="length"></intProp>
+		<intProp v="400" k="start"></intProp>
+		<strProp v="," k="pos"></strProp>
+		<edge toType="TOK" to="96" type="next"></edge>
+	</node>
+	<node id="110" type="TOK">
+		<intProp v="3" k="length"></intProp>
+		<intProp v="148" k="start"></intProp>
+		<strProp v="VBD" k="pos"></strProp>
+		<edge toType="TOK" to="87" type="next"></edge>
+	</node>
+	<node id="25" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="368" k="start"></intProp>
+		<strProp v="NNP" k="pos"></strProp>
+		<edge toType="TOK" to="111" type="next"></edge>
+	</node>
+	<node id="111" type="TOK">
+		<intProp v="2" k="length"></intProp>
+		<intProp v="373" k="start"></intProp>
+		<strProp v="RB" k="pos"></strProp>
+		<edge toType="TOK" to="109" type="next"></edge>
+	</node>
+	<node id="74" type="TOK">
+		<intProp v="1" k="length"></intProp>
+		<intProp v="265" k="start"></intProp>
+		<strProp v="," k="pos"></strProp>
+		<edge toType="TOK" to="106" type="next"></edge>
+	</node>
+	<node id="47" type="TOK">
+		<intProp v="1" k="length"></intProp>
+		<intProp v="51" k="start"></intProp>
+		<strProp v="," k="pos"></strProp>
+		<edge toType="TOK" to="108" type="next"></edge>
+	</node>
+	<node id="78" type="TOK">
+		<intProp v="6" k="length"></intProp>
+		<intProp v="336" k="start"></intProp>
+		<strProp v="VB" k="pos"></strProp>
+	</node>
+	<node id="39" type="TOK">
+		<intProp v="1" k="length"></intProp>
+		<intProp v="141" k="start"></intProp>
+		<strProp v="," k="pos"></strProp>
+		<edge toType="TOK" to="31" type="next"></edge>
+	</node>
+	<node id="16" type="TOK">
+		<intProp v="4" k="length"></intProp>
+		<intProp v="87" k="start"></intProp>
+		<strProp v="NN" k="pos"></strProp>
+		<edge toType="TOK" to="79" type="next"></edge>
+	</node>
+	<node id="112" type="PARTICIPANT">
+		<strProp v="cool hand mary" k="alias"></strProp>
+		<strProp v="mary" k="name"></strProp>
+		<strProp v="author" k="type"></strProp>
+		<strProp v="copied" k="type"></strProp>
+	</node>
+</document>


### PR DESCRIPTION
Overview
Since some properties can have an arity greater than 1, we had to change the internal structure of the property hash to be an array of objects at a key instead of a single object.

Testing
Review diff, run npm test and confirm the tests pass
