### PR TITLE
Bugfix/pagi 166 return empty arrays

### DIFF
--- a/src/js/graph/node.js
+++ b/src/js/graph/node.js
@@ -45,7 +45,9 @@ Node.prototype.addProp = function(type, key, val) {
     }
 };
 Node.prototype.getProp = function(key) {
-    return this._properties[key] && this._properties[key].vals.map(function(val) {
+    if (this._properties[key] === undefined) { return []; }
+
+    return this._properties[key].vals.map(function(val) {
         return val;
     });
 };

--- a/src/js/schema/propertySpec.js
+++ b/src/js/schema/propertySpec.js
@@ -51,7 +51,7 @@ PropertySpecBuilder.prototype.withDescription = function(description) {
 };
 
 PropertySpecBuilder.prototype.withPriority = function(priority) {
-	this.priority = priority;
+	this.priority = parseFloat(priority);
 	return this;
 };
 


### PR DESCRIPTION
Overview
Returns an empty array for properties that don't exist to keep the interface consistent. It also includes parsing priority to a number from a string so sorting works

Testing
Confirm tests pass. In NAUT, open a file and confirm that subtypes display for POS and Extractor
