### PR TITLE
Bugfix/pagi 172 delete with broken edges

### DIFF
--- a/src/js/graph/graph.js
+++ b/src/js/graph/graph.js
@@ -85,7 +85,6 @@ Graph.prototype.removeNode = function(node) {
     if (!(node instanceof Node)) {
         throw Error("Parameter must be an instance of Node when calling Graph.removeNode.");
     }
-    node.removeEdges();
     this._nodeTypes[node.getType()] = this._nodeTypes[node.getType()].filter(function(aNode) {
         return aNode.getId() !== node.getId();
     });

--- a/src/js/graph/graph.js
+++ b/src/js/graph/graph.js
@@ -85,6 +85,7 @@ Graph.prototype.removeNode = function(node) {
     if (!(node instanceof Node)) {
         throw Error("Parameter must be an instance of Node when calling Graph.removeNode.");
     }
+    node.removeEdges();
     this._nodeTypes[node.getType()] = this._nodeTypes[node.getType()].filter(function(aNode) {
         return aNode.getId() !== node.getId();
     });

--- a/src/js/graph/node.js
+++ b/src/js/graph/node.js
@@ -183,10 +183,12 @@ Node.prototype.removeEdge = function(aEdge) {
     // console.log("REMOVE EDGE nodeId: " + this.getId() + ", targetId: " + aEdge.getTargetId() + ", targetType: " + aEdge.getTargetType() + ", edgeType: " + aEdge.getEdgeType() + ".");
     this._edges = this._edges.filter(function(edge) {
         var edgeNode = this._graph.getNodeById(edge.getTargetId());
+        if (edgeNode) {
+            // If the target node exists in the graph, remove the edge from the graphImpl.
+            // console.log("UNLINK EDGE nodeId: " + this.getId() + ", targetId: " + edgeNode.getId() + ", type: " + edge.getEdgeType() + ".");
+            this._graph.removeEdge(this.getId(), edgeNode.getId(), edge.getEdgeType());
+        }
 
-        // Remove the edge from the graphImpl.
-        // console.log("UNLINK EDGE nodeId: " + this.getId() + ", targetId: " + edgeNode.getId() + ", type: " + edge.getEdgeType() + ".");
-        this._graph.removeEdge(this.getId(), edgeNode.getId(), edge.getEdgeType());
         // Only keep edges that don't match the one provided.
         return aEdge !== edge;
     }, this);

--- a/test/graph/graph-mary-manipulation-test.js
+++ b/test/graph/graph-mary-manipulation-test.js
@@ -109,6 +109,12 @@ describe('Graph manipulation for `mary` stream', function() {
             assert.equal(graph.getNodesByType(node.getType()).length, nodeTypeCnt - 1);
             assert.equal(graph.getNodeById(node.getId()), null);
         });
+        it('works when there are broken edges', function() {
+            var tokNode = graph.getNodeById('77');
+            graph.removeNode(tokNode);
+            var sbNode = graph.getNodeById('71');
+            assert.doesNotThrow(function() { graph.removeNode(sbNode); });
+        });
         it('node\'s edges are removed properly for sequences', function() {
             assert(nextNode.hasPrevious());
             assert(nextNode.previous() === prevNode);


### PR DESCRIPTION
Overview

Fixes errors caused by deleting a node that has edges to non-existent nodes in the graph

Testing
Run npm test, ensure all tests pass.
