### PR TITLE
PAGI-174 added existence check for first and last edges

### DIFF
--- a/src/js/graph/node.js
+++ b/src/js/graph/node.js
@@ -347,11 +347,15 @@ Node.prototype.getParentsOfType = function(nodeType) {
 // SpanContainer trait functions
 Node.prototype.getFirst = function() {
     if (!this.hasTraitSpanContainer()) { throw Error("Calling `getFirst` on a Node that does not have the `span container` trait."); }
-    return this._graph.getNodeById(this.getFirstEdgeByType('first').getTargetId());
+    var firstEdge = this.getFirstEdgeByType('first');
+    if (!firstEdge) { return undefined; }
+    return this._graph.getNodeById(firstEdge.getTargetId());
 };
 Node.prototype.getLast = function() {
     if (!this.hasTraitSpanContainer()) { throw Error("Calling `getLast` on a Node that does not have the `span container` trait."); }
-    return this._graph.getNodeById(this.getFirstEdgeByType('last').getTargetId());
+    var lastEdge = this.getFirstEdgeByType('last');
+    if (!lastEdge) { return undefined; }
+    return this._graph.getNodeById(lastEdge.getTargetId());
 };
 
 module.exports = Node;

--- a/test/graph/graph-mary-manipulation-test.js
+++ b/test/graph/graph-mary-manipulation-test.js
@@ -134,5 +134,11 @@ describe('Graph manipulation for `mary` stream', function() {
             assert.equal(node.getFirstEdgeByType('next'), undefined);
             assert.equal(node.hasNext(), false);
         });
+        it('should return undefined if first or last edge is removed', function() {
+            var sbNode = graph.getNodeById('71');
+            sbNode.removeEdges();
+            assert(sbNode.getFirst() === undefined);
+            assert(sbNode.getLast() === undefined);
+        });
     });
 });


### PR DESCRIPTION
Overview
Node.getFirst & Node.getLast were throwing errors when those edges were missing

Testing
Added a new test case for this scenario, run npm test & ensure all tests pass. 
