### PR TITLE
Feature/pagi 170 refactor edge impl

### DIFF
--- a/src/js/graph/constants.js
+++ b/src/js/graph/constants.js
@@ -1,6 +1,5 @@
 'use strict';
 
-module.exports.CONTROL_NODE = 'internal control node';
 module.exports.VALID_PROP_TYPES = ['string', 'float', 'integer', 'boolean'];
 module.exports.STR_PROP = 0;
 module.exports.FLOAT_PROP = 1;

--- a/src/js/graph/constants.js
+++ b/src/js/graph/constants.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports.CONTROL_NODE = 'internal control node';
+module.exports.VALID_PROP_TYPES = ['string', 'float', 'integer', 'boolean'];
+module.exports.STR_PROP = 0;
+module.exports.FLOAT_PROP = 1;
+module.exports.INT_PROP = 2;
+module.exports.BOOL_PROP = 3;

--- a/src/js/graph/constants.js
+++ b/src/js/graph/constants.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports.CHILD_EDGE_TYPE = 'internal-node-tracking-child';

--- a/src/js/graph/edge.js
+++ b/src/js/graph/edge.js
@@ -10,6 +10,6 @@ function Edge(sourceId, targetId, targetType, edgeType) {
 Edge.prototype.getSourceId = function() { return this._sourceId; };
 Edge.prototype.getTargetId = function() { return this._targetId; };
 Edge.prototype.getTargetType = function() { return this._targetType; };
-Edge.prototype.getEdgeType = function() { return this._edgeType; };
+Edge.prototype.getType = function() { return this._edgeType; };
 
 module.exports = Edge;

--- a/src/js/graph/edge.js
+++ b/src/js/graph/edge.js
@@ -1,8 +1,10 @@
-function Edge(targetId, targetType, edgeType) {
+function Edge(sourceId, targetId, targetType, edgeType) {
+    this._sourceId = sourceId || null;
     this._targetId = targetId || null;
     this._targetType = targetType || null;
     this._edgeType = edgeType || null;
 }
+Edge.prototype.getSourceId = function() { return this._sourceId; };
 Edge.prototype.getTargetId = function() { return this._targetId; };
 Edge.prototype.getTargetType = function() { return this._targetType; };
 Edge.prototype.getEdgeType = function() { return this._edgeType; };

--- a/src/js/graph/edge.js
+++ b/src/js/graph/edge.js
@@ -1,8 +1,13 @@
-function Edge(targetId, targetType, edgeType) {
-    this._targetId = targetId || null;
-    this._targetType = targetType || null;
-    this._edgeType = edgeType || null;
+'use strict';
+
+function Edge(sourceId, targetId, targetType, edgeType) {
+  this._sourceId = sourceId || null;
+  this._targetId = targetId || null;
+  this._targetType = targetType || null;
+  this._edgeType = edgeType || null;
 }
+
+Edge.prototype.getSourceId = function() { return this._sourceId; };
 Edge.prototype.getTargetId = function() { return this._targetId; };
 Edge.prototype.getTargetType = function() { return this._targetType; };
 Edge.prototype.getEdgeType = function() { return this._edgeType; };

--- a/src/js/graph/graph.js
+++ b/src/js/graph/graph.js
@@ -166,10 +166,10 @@ Graph.prototype.getEdge = function(sourceId, targetId, edgeType) {
 Graph.prototype.removeEdge = function(sourceId, targetId, edgeType) {
     this._graphImpl.removeEdge(sourceId, targetId, edgeType);
 };
-Graph.prototype.connectEdges = function() {
+Graph.prototype.linkNodes = function() {
     // console.log("Graph.connectEdges ------------------------");
     this.getNodes().forEach(function(node) {
-        node.connectEdges();
+        node.linkInGraph();
     });
     // console.log("Graph.connectEdges ------------------------");
 };
@@ -179,14 +179,15 @@ Graph.prototype.inEdges = function(sourceId, targetId) {
 Graph.prototype.outEdges = function(sourceId, targetId) {
     return this._graphImpl.outEdges(sourceId, targetId);
 };
-Graph.prototype.hasEdge = function(sourceId, targetId, type) {
+Graph.prototype.edgeExists = function(sourceId, targetId, type) {
     return this._graphImpl.hasEdge(sourceId, targetId, type);
 };
 
 // Manipulation functions
-Graph.prototype.createNode = function(id, type) {
-    id = id || this._generateNodeId();
+Graph.prototype.createNode = function(type, id) {
     if (type === undefined || type === null) { throw Error('type is a required param for `createNode`'); }
+    id = id || this._generateNodeId();
+
     var newNode = new Node(id, this, type);
     this.addNode(newNode, false);
     return this.getNodeById(id);

--- a/src/js/graph/graph.js
+++ b/src/js/graph/graph.js
@@ -4,7 +4,6 @@ var Node = require('./node');
 var Edge = require('./edge');
 var GraphImpl = require('graphlib').Graph;
 var utils = require('../util');
-var CONTROL_NODE = require('./constants').CONTROL_NODE;
 var deepClone = utils.deepClone;
 
 function Graph(id) {
@@ -19,8 +18,7 @@ function Graph(id) {
     this._nodeTypes = { };
     this._graphImpl = new GraphImpl({
         directed: true,
-        multigraph: true,
-        compound: true
+        multigraph: true
     });
 }
 
@@ -90,17 +88,6 @@ Graph.prototype.getNodesByType = function(nodeType) {
     return this._nodeTypes[nodeType].map(function(node) {
         return node;
     });
-};
-Graph.prototype.getNodeIds = function() {
-    return this._graphImpl.nodes();
-};
-Graph.prototype._getAllNodeIds = function() {
-    return this._graphImpl.nodes();
-};
-Graph.prototype.getNodes = function() {
-    return this.getNodeIds().map(function(nodeId) {
-        return this.getNodeById(nodeId);
-    }, this);
 };
 Graph.prototype.addNode = function(node, linkInGraph) {
     if (!(node instanceof Node)) {

--- a/src/js/graph/graph.js
+++ b/src/js/graph/graph.js
@@ -1,6 +1,9 @@
 var Node = require('./node');
+var Edge = require('./edge');
 var GraphImpl = require('graphlib').Graph;
-var deepClone = require('../util').deepClone;
+var utils = require('../util');
+var CONTROL_NODE = require('./constants').CONTROL_NODE;
+var deepClone = utils.deepClone;
 
 function Graph(id) {
     this._id = id || null;
@@ -12,7 +15,11 @@ function Graph(id) {
     this._sequenceNodeTypes = { };
     this._spanContainerNodeTypes = { };
     this._nodeTypes = { };
-    this._graphImpl = new GraphImpl({ multigraph: true });
+    this._graphImpl = new GraphImpl({
+        directed: true,
+        multigraph: true,
+        compound: true
+    });
 }
 
 Graph.prototype.setId = function(id) { this._id = id; };
@@ -25,18 +32,21 @@ Graph.prototype.addSchemaUri = function(uri) {
 Graph.prototype.getSchemaUris = function() {
     return this._schemaUris.map(function(schema) { return schema; });
 };
+
 Graph.prototype.setContent = function(content) {
     this._content = content;
 };
 Graph.prototype.getContent = function() {
     return this._content;
 };
+
 Graph.prototype.setContentType = function(contentType) {
     this._contentType = contentType;
 };
 Graph.prototype.getContentType = function() {
     return this._contentType;
 };
+
 Graph.prototype.setNodeTypeAsSpan = function(nodeType, attrMap) {
     this._spanNodeTypes[nodeType] = attrMap || { };
 };
@@ -44,6 +54,7 @@ Graph.prototype.getNodeTypesAsSpan = function() {
     // Don't return a direct reference to the object.
     return deepClone(this._spanNodeTypes);
 };
+
 Graph.prototype.setNodeTypeAsSequence = function(nodeType, attrMap) {
     this._sequenceNodeTypes[nodeType] = attrMap || { };
 };
@@ -51,6 +62,7 @@ Graph.prototype.getNodeTypesAsSequence = function() {
     // Don't return a direct reference to the object.
     return deepClone(this._sequenceNodeTypes);
 };
+
 Graph.prototype.setNodeTypeAsSpanContainer = function(nodeType, attrMap) {
     this._spanContainerNodeTypes[nodeType] = attrMap || { };
 };
@@ -58,89 +70,73 @@ Graph.prototype.getNodeTypesAsSpanContainer = function() {
     // Don't return a direct reference to the object.
     return deepClone(this._spanContainerNodeTypes);
 };
+
+// Node manipulation functions
+Graph.prototype.nodeExists = function(nodeId) { return this._graphImpl.hasNode(nodeId); };
+Graph.prototype.getNodeById = function(nodeId) { return this._graphImpl.node(nodeId); };
+Graph.prototype.getNodeTypes = function() { return Object.keys(this._nodeTypes); };
+Graph.prototype.getNodesByType = function(nodeType) {
+    return this._graphImpl.children(nodeType).map(function(nodeId) {
+        return this.getNodeById(nodeId);
+    }, this);
+};
+Graph.prototype.getNodeIds = function() {
+    // control nodes have non-int ids, filter them out
+    return this._graphImpl.nodes().filter(function(nodeId) {
+        return !isNaN(parseInt(nodeId));
+    });
+};
+Graph.prototype.getNodes = function() {
+    return this.getNodeIds().map(function(nodeId) {
+        return this.getNodeById(nodeId);
+    }, this);
+};
 Graph.prototype.addNode = function(node, connectEdges) {
     if (!(node instanceof Node)) {
-        throw Error("Parameter must be an instance of Node when calling Graph.addNode.");
+        throw Error('Parameter must be an instance of Node when calling Graph.addNode.');
     }
     if (node.getType() === null) {
-        throw Error("Adding a node to the graph must have a TYPE.");
+        throw Error('Adding a node to the graph must have a TYPE.');
     }
-    if (this.getNodeById(node.getId()) !== undefined) {
-        throw Error("Graph already contains a node with id `" + node.getId() + "`.");
+    if (this.nodeExists(node.getId())) {
+        throw Error('Graph already contains a node with id `' + node.getId() + '`.');
     }
     if (!node.getId()) {
-        var id = this._generateNodeId();
-        node.setId(id);
+        node.setId(this._generateNodeId());
     }
     // console.log("ADD NODE id: " + node.getId() + ", type: " + node.getType() + ".");
-    connectEdges = connectEdges === undefined ? true : false;
+    connectEdges = connectEdges === undefined ? true : connectEdges;
     this._graphImpl.setNode(node.getId(), node);
     node.setGraph(this);
-    // Create node type buckets.
-    this._nodeTypes[node.getType()] = this._nodeTypes[node.getType()] || [];
-    this._nodeTypes[node.getType()].push(node);
+    // Create control node and set child relationship for node type.
+    if (!this.nodeExists(node.getType())) {
+        this._graphImpl.setNode(node.getType(), CONTROL_NODE);
+    }
+    this._graphImpl.setParent(node.getId(), node.getType());
     if (connectEdges) { node.connectEdges(); }
 };
 Graph.prototype.removeNode = function(node) {
     if (!(node instanceof Node)) {
-        throw Error("Parameter must be an instance of Node when calling Graph.removeNode.");
-    }
-    node.removeEdges();
-    this._nodeTypes[node.getType()] = this._nodeTypes[node.getType()].filter(function(aNode) {
-        return aNode.getId() !== node.getId();
-    });
-    if (this._nodeTypes[node.getType()].length === 0) {
-        delete this._nodeTypes[node.getType()];
+        throw Error('Parameter must be an instance of Node when calling Graph.removeNode.');
     }
     node.removeGraph();
     this._graphImpl.removeNode(node.getId());
 };
-function logEdgeError(graph, sourceId, targetId, edgeType) {
-    var message;
-
-    if (!graph.getNodeById(sourceId) && !graph.getNodeById(targetId)) {
-        message = [
-            'Cannot create `',
-            edgeType,
-            '` edge between non-existent node ids `',
-            sourceId,
-            '` and `',
-            targetId,
-            '`.'
-        ].join('');
-    } else if (!graph.getNodeById(sourceId)) {
-        message = [
-            'Cannot create `',
-            edgeType,
-            '` edge from non-existent node id `',
-            sourceId,
-            '` to node id `',
-            targetId,
-            '`.'
-        ].join('');
-    } else if (!graph.getNodeById(targetId)) {
-        message = [
-            'Cannot create `',
-            edgeType,
-            '` edge from node id `',
-            sourceId,
-            '` to non-existent node id `',
-            targetId,
-            '`.'
-        ].join('');
-    }
-
-    if (message) { console.warn(message); }
-    return message;
-}
-Graph.prototype.setEdge = function(sourceId, targetId, edgeType) {
-    if (!this.getNodeById(sourceId) || !this.getNodeById(targetId)) {
-        return logEdgeError(this, sourceId, targetId, edgeType);
-    }
-    this._graphImpl.setEdge(sourceId, targetId, edgeType);
+// Edge manipulation functions
+Graph.prototype.edgeExists = function(sourceId, targetId, edgeType) {
+    return this._graphImpl.hasEdge(sourceId, targetId, edgeType);
 };
-Graph.prototype.getEdge = function(sourceId, targetId) {
-    return this._graphImpl.edge(sourceId, targetId);
+Graph.prototype.addEdge = function(sourceId, targetId, edgeType, targetType) {
+    if (!this.nodeExists(sourceId) || !this.nodeExists(targetId)) {
+        return utils.logEdgeError(this, sourceId, targetId, edgeType);
+    }
+    targetType = targetType || this.getNodeById(targetId).getType();
+    var edge = new Edge(sourceId, targetId, targetType, edgeType);
+
+    this._graphImpl.setEdge(sourceId, targetId, edge, edgeType);
+};
+Graph.prototype.getEdge = function(sourceId, targetId, edgeType) {
+    return this._graphImpl.edge(sourceId, targetId, edgeType);
 };
 Graph.prototype.removeEdge = function(sourceId, targetId, edgeType) {
     this._graphImpl.removeEdge(sourceId, targetId, edgeType);
@@ -152,36 +148,28 @@ Graph.prototype.connectEdges = function() {
     });
     // console.log("Graph.connectEdges ------------------------");
 };
-Graph.prototype.getNodeById = function(nodeId) { return this._graphImpl.node(nodeId); };
-Graph.prototype.getNodeTypes = function() { return Object.keys(this._nodeTypes); };
-Graph.prototype.getNodesByType = function(nodeType) {
-    if (this._nodeTypes[nodeType] === undefined) { return []; }
-    return this._nodeTypes[nodeType].map(function(node) {
-        return node;
-    });
-};
-Graph.prototype.getNodeIds = function() {
-    return this._graphImpl.nodes();
-};
-Graph.prototype.getNodes = function() {
-    return this.getNodeIds().map(function(nodeId) {
-        return this.getNodeById(nodeId);
-    }, this);
-};
 
 // Manipulation functions
-Graph.prototype.createNode = function() {
-    return new Node();
+Graph.prototype.createNode = function(id, type) {
+    id = id || this._generateNodeId;
+    if (type === undefined || type === null) { throw Error('type is a required param for `createNode`'); }
+    var newNode = new Node(id, this, type);
+    this.addNode(newNode, false);
+    return this.getNodeById(id);
 };
 
 // Hidden functions
 Graph.prototype._generateNodeId = function() {
+    var currentMaxId = this.getNodes().reduce(function getCurrentMaxId(minId, node) {
+        var nodeId = parseInt(node.getId());
+        var maxId = nodeId > minId ? nodeId : minId;
+
+        return maxId;
+    }, 0);
+
     // Increment the max id by one to get the new id.
-    return (this.getNodes().reduce(function(minId, node) {
-        var nodeId = node.getId() ? parseInt(node.getId()) : -1;
-        if (nodeId > minId) { return nodeId; }
-        return minId;
-    }, 0) + 1).toString();
+    var newMaxId = currentMaxId + 1;
+    return newMaxId.toString();
 };
 
 module.exports = Graph;

--- a/src/js/graph/graph.js
+++ b/src/js/graph/graph.js
@@ -130,7 +130,7 @@ Graph.prototype.removeNode = function(node) {
 Graph.prototype.edgeExists = function(sourceId, targetId, edgeType) {
     return this._graphImpl.hasEdge(sourceId, targetId, edgeType);
 };
-Graph.prototype.addEdge = function(sourceId, targetId, edgeType, toType) {
+Graph.prototype._addEdge = function(sourceId, targetId, edgeType, toType) {
     if (!this.nodeExists(sourceId) || !this.nodeExists(targetId)) {
         return utils.logEdgeTargetError(this, sourceId, targetId, edgeType);
     }
@@ -140,23 +140,23 @@ Graph.prototype.addEdge = function(sourceId, targetId, edgeType, toType) {
 
     this._graphImpl.setEdge(sourceId, targetId, newEdge, edgeType);
 };
-Graph.prototype.addEdges = function(edges) {
+Graph.prototype._addEdges = function(edges) {
     edges.forEach(function(edge) {
-        this.addEdge(edge.getSourceId(), edge.getTargetId(), edge.getType(), edge.getTargetType());
+        this._addEdge(edge.getSourceId(), edge.getTargetId(), edge.getType(), edge.getTargetType());
     }, this);
 };
 Graph.prototype.getEdge = function(sourceId, targetId, edgeType) {
     return this._graphImpl.edge(sourceId, targetId, edgeType);
 };
-Graph.prototype.removeEdge = function(sourceId, targetId, edgeType) {
+Graph.prototype._removeEdge = function(sourceId, targetId, edgeType) {
     this._graphImpl.removeEdge(sourceId, targetId, edgeType);
 };
 Graph.prototype.linkNodes = function() {
-    // console.log("Graph.connectEdges ------------------------");
+    // console.log("Graph.linkNodes ------------------------");
     this.getNodes().forEach(function(node) {
         node.linkInGraph();
     });
-    // console.log("Graph.connectEdges ------------------------");
+    // console.log("Graph.linkNodes ------------------------");
 };
 Graph.prototype.inEdges = function(sourceId, targetId) {
     return this._graphImpl.inEdges(sourceId, targetId);

--- a/src/js/graph/node.js
+++ b/src/js/graph/node.js
@@ -1,14 +1,15 @@
-var Edge = require('./edge');
 var VALID_PROP_TYPES = ['string', 'float', 'integer', 'boolean'];
+var CHILD_EDGE_TYPE = require('./constants').CHILD_EDGE_TYPE;
+var Edge = require('./edge');
 
 function Node(id, type) {
     this._id = id || null;
     this._type = type || null;
     this._features = { };
     this._properties = { };
-    this._edges = [];
     this._graph = null;
 }
+
 Node.prototype.setId = function(id) { this._id = id; };
 Node.prototype.getId = function() { return this._id; };
 Node.prototype.setType = function(type) { this._type = type; };
@@ -60,16 +61,20 @@ Node.prototype.getProps = function() {
 };
 Node.prototype.addEdge = function(targetId, targetType, edgeType, connectEdges) {
     // console.log("ADD EDGE for nodeId: " + this.getId() + ", targetId: " + targetId + ", targetType: " + targetType + ", edgeType: " + edgeType + ".");
-    this._edges.push(new Edge(targetId, targetType, edgeType));
-    connectEdges = connectEdges === undefined ? true : connectEdges;
+    connectEdges = (connectEdges === undefined) ? true : connectEdges;
+
+    this._graph.setEdge(this.getId(), targetId, edgeType, targetType);
+
     if (connectEdges) { this.connectEdges(); }
 };
 Node.prototype.getEdges = function() {
-    return this._edges.map(function(edge) { return edge; });
+    return this._graph.outEdges(this.getId()).map(function(edge) {
+        return this._graph.getEdge(edge.v, edge.w, edge.name);
+    }, this);
 };
 Node.prototype.getEdgesByType = function(edgeType) {
-    return this._edges.filter(function(edge) {
-        return edge.getEdgeType() === edgeType;
+    return this.getEdges().filter(function(edge) {
+        return edge.edgeType === edgeType;
     });
 };
 Node.prototype.getFirstEdgeByType = function(edgeType) {
@@ -91,6 +96,10 @@ Node.prototype.setGraph = function(graph) {
 Node.prototype.removeGraph = function() { this._graph = null; };
 Node.prototype.connectEdges = function() {
     if (!this._graph) { return; }
+
+    this._connectEdgesSpanContainer();
+    this._connectEdgesSequence();
+
     var graph = this._graph;
     this.getEdges().forEach(function(edge) {
         // Check if the edge exists before creating it.
@@ -122,9 +131,9 @@ Node.prototype._connectEdgesSpanContainer = function() {
             }
             // console.log("Node._connectEdgesSpanContainer: Checking node '" + linkNode.getId() + "', type: '" + linkNode.getType() + "'.");
             // Don't create the edge if it already exists
-            if (!graph.getEdge(this.getId(), linkNode.getId())) {
+            if (!graph.hasEdge(this.getId(), linkNode.getId(), CHILD_EDGE_TYPE)) {
                 // console.log("LINK EDGE nodeId: " + this.getId() + ", targetId: " + linkNode.getId() + ", type: child.");
-                graph.setEdge(this.getId(), linkNode.getId(), 'child');
+                graph.setEdge(this.getId(), linkNode.getId(), CHILD_EDGE_TYPE);
             }
             if (linkNode === lastNode) {
                 // console.log("Node._connectEdgesSpanContainer: LinkNode === LastNode.");
@@ -160,15 +169,15 @@ Node.prototype._connectEdgesSequence = function() {
         prevNode.addEdge(self.getId(), self.getType(), 'next');
         // Next node is already added via the generic edge loop above.
         // Set parent edges based on this node's neighbors
-        var prevInEdgeImpls = prevNode._getEdgesImplByLabels('in', ['first', 'last', 'child']);
-        var nextInEdgeImpls = self.next()._getEdgesImplByLabels('in', ['first', 'last', 'child']);
+        var prevInEdgeImpls = prevNode._getEdgesImplByLabels('in', ['first', 'last', CHILD_EDGE_TYPE]);
+        var nextInEdgeImpls = self.next()._getEdgesImplByLabels('in', ['first', 'last', CHILD_EDGE_TYPE]);
         // Matching parents between the prev and next nodes will be applied to this node.
         prevInEdgeImpls.forEach(function(prevInEdgeImpl) {
             nextInEdgeImpls.forEach(function(nextInEdgeImpl) {
                 if (prevInEdgeImpl.v == nextInEdgeImpl.v) {
                     var prevParentNode = self._graph.getNodeById(prevInEdgeImpl.v);
                     // console.log("LINK EDGE nodeId: " + prevParentNode.getId() + ", targetId: " + self.getId() + ", type: child.");
-                    self._graph.setEdge(prevParentNode.getId(), self.getId(), 'child');
+                    self._graph.setEdge(prevParentNode.getId(), self.getId(), CHILD_EDGE_TYPE);
                 }
             });
         });
@@ -315,7 +324,7 @@ Node.prototype._getParentsOfType = function(fnName, nodeType, stopOnFirst) {
     }
     var currentNode, parentEdges, i, matchingNodes = [], self = this;
     // Store nodes that need to be visited in the currentNodes array.
-    var currentNodes = this._getEdgesImplByLabels('in', ['child']).map(function(edgeImpl) {
+    var currentNodes = this._getEdgesImplByLabels('in', [CHILD_EDGE_TYPE]).map(function(edgeImpl) {
         return self._graph.getNodeById(edgeImpl.v);
     });
     while (true) {
@@ -328,7 +337,7 @@ Node.prototype._getParentsOfType = function(fnName, nodeType, stopOnFirst) {
             else { matchingNodes.push(currentNode); }
         }
         // Node was not the right type, check it's parents.
-        parentEdges = currentNode._getEdgesImplByLabels('in', ['child']);
+        parentEdges = currentNode._getEdgesImplByLabels('in', [CHILD_EDGE_TYPE]);
         for (i = 0; i < parentEdges.length; i++) {
             currentNodes.push(self._graph.getNodeById(parentEdges[i].v));
         }

--- a/src/js/graph/node.js
+++ b/src/js/graph/node.js
@@ -1,13 +1,20 @@
-var Edge = require('./edge');
-var VALID_PROP_TYPES = ['string', 'float', 'integer', 'boolean'];
+'use strict';
 
-function Node(id, type) {
+var Edge = require('./edge');
+var constants = require('./constants');
+var VALID_PROP_TYPES = constants.VALID_PROP_TYPES;
+var STR_PROP = constants.STR_PROP;
+var FLOAT_PROP = constants.FLOAT_PROP;
+var INT_PROP = constants.INT_PROP;
+var BOOL_PROP = constants.BOOL_PROP;
+
+function Node(id, graph, type) {
     this._id = id || null;
     this._type = type || null;
     this._features = { };
     this._properties = { };
     this._edges = [];
-    this._graph = null;
+    this._graph = graph;
 }
 
 Node.prototype.setId = function(id) { this._id = id; };
@@ -17,13 +24,13 @@ Node.prototype.getType = function() { return this._type; };
 function convertValue(type, value) {
     var newVal;
     switch (type) {
-        case VALID_PROP_TYPES[0]:
+        case VALID_PROP_TYPES[STR_PROP]:
             newVal = value.toString(); break;
-        case VALID_PROP_TYPES[1]:
+        case VALID_PROP_TYPES[FLOAT_PROP]:
             newVal = parseFloat(value); break;
-        case VALID_PROP_TYPES[2]:
+        case VALID_PROP_TYPES[INT_PROP]:
             newVal = parseInt(value); break;
-        case VALID_PROP_TYPES[3]:
+        case VALID_PROP_TYPES[BOOL_PROP]:
             newVal = value === 'true'; break;
         default:
             throw Error('Unknown Node property type `' + type + '`.');
@@ -100,7 +107,7 @@ Node.prototype.connectEdges = function() {
         this._connectEdgesSpanContainer();
         this._connectEdgesSequence();
         // console.log("LINK EDGE nodeId: " + this.getId() + ", targetId: " + edge.getTargetId() + ", type: " + edge.getEdgeType() + ".");
-        graph.setEdge(this.getId(), edge.getTargetId(), edge.getEdgeType());
+        graph.addEdge(this.getId(), edge.getTargetId(), edge.getEdgeType());
     }, this);
 };
 // If node is a span container create edges to all it's children.

--- a/src/js/graph/node.js
+++ b/src/js/graph/node.js
@@ -72,7 +72,7 @@ Node.prototype.addEdge = function(targetId, edgeType, targetType, linkInGraph) {
     // console.log("ADD EDGE for nodeId: " + this.getId() + ", targetId: " + targetId + ", targetType: " + targetType + ", edgeType: " + edgeType + ".");
     linkInGraph = (linkInGraph === undefined) ? true : linkInGraph;
 
-    this._graph.addEdge(this.getId(), targetId, edgeType, targetType);
+    this._graph._addEdge(this.getId(), targetId, edgeType, targetType);
 
     if (linkInGraph) { this.linkInGraph(); }
 };
@@ -130,7 +130,7 @@ function connectNodesInSequence(node) {
                 if (prevInEdgeImpl.v === nextInEdgeImpl.v) {
                     var prevParentNode = node._graph.getNodeById(prevInEdgeImpl.v);
                     // console.log("LINK EDGE nodeId: " + prevParentNode.getId() + ", targetId: " + node.getId() + ", type: child.");
-                    node._graph.addEdge(prevParentNode.getId(), node.getId(), CHILD_EDGE_TYPE);
+                    node._graph._addEdge(prevParentNode.getId(), node.getId(), CHILD_EDGE_TYPE);
                 }
             });
         });
@@ -158,7 +158,7 @@ function connectSpanContainerParents(node) {
             // Don't create the edge if it already exists
             if (!graph.edgeExists(node.getId(), linkNode.getId(), CHILD_EDGE_TYPE)) {
                 // console.log("LINK EDGE nodeId: " + this.getId() + ", targetId: " + linkNode.getId() + ", type: child.");
-                graph.addEdge(node.getId(), linkNode.getId(), CHILD_EDGE_TYPE);
+                graph._addEdge(node.getId(), linkNode.getId(), CHILD_EDGE_TYPE);
             }
             if (linkNode === lastNode) {
                 // console.log("Node._connectEdgesSpanContainer: LinkNode === LastNode.");
@@ -193,7 +193,7 @@ Node.prototype.removeEdge = function(edge) {
     }
 
     // console.log("REMOVE EDGE nodeId: " + this.getId() + ", targetId: " + aEdge.getTargetId() + ", targetType: " + aEdge.getTargetType() + ", edgeType: " + aEdge.getType() + ".");
-    this._graph.removeEdge(this.getId(), edge.getTargetId(), edge.getType());
+    this._graph._removeEdge(this.getId(), edge.getTargetId(), edge.getType());
 };
 Node.prototype.removeEdges = function() {
     var self = this;

--- a/src/js/graph/node.js
+++ b/src/js/graph/node.js
@@ -112,13 +112,21 @@ function connectNodesInSequence(node) {
     // A -> B
     // A C -> B
     // A -> C -> B
-    if (node.hasNext() && !node.hasPrevious() &&
+    if (node._id == '9000000') {
+        console.log('hasNext', node.hasNext());
+        console.log('!hasPrevious()', !node.hasPrevious());
+        console.log('.next().hasPrevious()', node.next().hasPrevious());
+        console.log('.next().previous() !== node', node.next().previous() !== node);
+    }
+    if (node.hasNext() &&
+        !node.hasPrevious() &&
         node.next().hasPrevious() &&
         node.next().previous() !== node
     ) {
         var prevNode = node.next().previous();
+        console.log('I FIRED', prevNode);
         prevNode.removeEdge(prevNode.getFirstEdgeByType('next'));
-        prevNode.addEdge(node.getId(), 'next', node.getType());
+        prevNode.addEdge(node.getId(), 'next');
         // Next node is already added via the generic edge loop above.
         // Set parent edges based on this node's neighbors
         var prevInEdgeImpls = prevNode._getEdgesImplByLabels('in', ['first', 'last', CHILD_EDGE_TYPE]);
@@ -180,7 +188,7 @@ Node.prototype.linkInGraph = function() {
     if (!this._graph) { return console.warn('Node is not part of a graph, cannot run linkNodes'); }
     // must connect sequences before trying to set parent edges
     connectNodesInSequence(this);
-    connectSpanContainerParents(this);
+    // connectSpanContainerParents(this);
 };
 
 Node.prototype.removeEdge = function(edge) {
@@ -290,7 +298,7 @@ Node.prototype.hasPrevious = function() {
     // Special case, there will not be an explicit `previous` edge.
     // This library assumes a sequence node will only ever have one incoming `next` edge.
     var previousImplEdges = this._getEdgesImplByLabels('in', ['next']);
-    return previousImplEdges.length === 1;
+    return previousImplEdges.length > 0;
 };
 Node.prototype.next = function() {
     if (!this.hasTraitSequence()) { throw Error("Calling `next` on a Node that does not have the `sequence` trait."); }
@@ -309,8 +317,7 @@ Node.prototype.previous = function() {
 };
 Node.prototype._getEdgesImplByLabels = function(direction, labels)  {
     return this._graph[direction + 'Edges'](this.getId()).filter(function(edgeImpl) {
-        console.log(edgeImpl);
-        return labels.indexOf(this.edgeExists(edgeImpl.v, edgeImpl.w, edgeImpl.name)) !== -1;
+        return labels.indexOf(edgeImpl.name) !== -1;
     }, this._graph);
 };
 // Breadth-first search for parents of a given node type.

--- a/src/js/graph/node.js
+++ b/src/js/graph/node.js
@@ -9,6 +9,7 @@ function Node(id, type) {
     this._edges = [];
     this._graph = null;
 }
+
 Node.prototype.setId = function(id) { this._id = id; };
 Node.prototype.getId = function() { return this._id; };
 Node.prototype.setType = function(type) { this._type = type; };

--- a/src/js/graph/node.js
+++ b/src/js/graph/node.js
@@ -70,7 +70,7 @@ Node.prototype.addEdge = function(targetId, targetType, edgeType, connectEdges) 
     // console.log("ADD EDGE for nodeId: " + this.getId() + ", targetId: " + targetId + ", targetType: " + targetType + ", edgeType: " + edgeType + ".");
     connectEdges = (connectEdges === undefined) ? true : connectEdges;
 
-    this._graph.setEdge(this.getId(), targetId, edgeType, targetType);
+    this._graph.addEdge(this.getId(), targetId, edgeType, targetType);
 
     if (connectEdges) { this.connectEdges(); }
 };

--- a/src/js/graph/parsers/graphParserXml.js
+++ b/src/js/graph/parsers/graphParserXml.js
@@ -65,7 +65,7 @@ GraphParserXml.prototype.parse = function(readableStream) {
                     break;
                 case 'node':
                     try {
-                        node = graph.createNode(tag.attributes.id.value, tag.attributes.type.value);
+                        node = graph.createNode(tag.attributes.type.value, tag.attributes.id.value);
                     } catch (err) {
                         reject(new Error("Failed to parse node `id` and `type`. [" + err + "]"));
                     }
@@ -171,7 +171,7 @@ GraphParserXml.prototype.parse = function(readableStream) {
         });
         streamParser.on("end", function() {
             graph.addEdges(edges);
-            graph.connectEdges();
+            graph.linkNodes();
             resolve(graph);
         });
         streamParser.on("error", function(err) {

--- a/src/js/graph/parsers/graphParserXml.js
+++ b/src/js/graph/parsers/graphParserXml.js
@@ -64,11 +64,8 @@ GraphParserXml.prototype.parse = function(readableStream) {
                     }
                     break;
                 case 'node':
-                    node = new Node();
                     try {
-                        node.setId(tag.attributes.id.value);
-                        node.setType(tag.attributes.type.value);
-                        graph.addNode(node, false);
+                        node = graph.createNode(tag.attributes.id.value, tag.attributes.type.value);
                     } catch (err) {
                         reject(new Error("Failed to parse node `id` and `type`. [" + err + "]"));
                     }
@@ -173,7 +170,7 @@ GraphParserXml.prototype.parse = function(readableStream) {
             }
         });
         streamParser.on("end", function() {
-            graph.setEdges(edges);
+            graph.addEdges(edges);
             graph.connectEdges();
             resolve(graph);
         });

--- a/src/js/graph/parsers/graphParserXml.js
+++ b/src/js/graph/parsers/graphParserXml.js
@@ -165,7 +165,7 @@ GraphParserXml.prototype.parse = function(readableStream) {
             }
         });
         streamParser.on("end", function() {
-            graph.addEdges(edges);
+            graph._addEdges(edges);
             graph.linkNodes();
             resolve(graph);
         });

--- a/src/js/graph/parsers/graphParserXml.js
+++ b/src/js/graph/parsers/graphParserXml.js
@@ -21,6 +21,7 @@ GraphParserXml.prototype.parse = function(readableStream) {
             'bool': 'boolean'
         };
         var multiValData = null;
+        var edges = [];
 
         streamParser.on("opentag", function(tag) {
             currentTag = tag;
@@ -133,7 +134,13 @@ GraphParserXml.prototype.parse = function(readableStream) {
                     if (node) {
                         try {
                             var eAttrs = tag.attributes;
-                            node.addEdge(eAttrs.to.value, eAttrs.toType.value, eAttrs.type.value, false);
+                            edges.push({
+                                sourceId: node.getId(),
+                                targetId: eAttrs.to.value,
+                                type: eAttrs.type.value,
+                                toType: eAttrs.toType.value
+                            });
+                            // node.addEdge(eAttrs.to.value, eAttrs.toType.value, eAttrs.type.value, false);
                         } catch (err) {
                             reject(new Error("Failed to parse edge for node `" + node.id + "`. [" + err + "]"));
                         }
@@ -166,6 +173,7 @@ GraphParserXml.prototype.parse = function(readableStream) {
             }
         });
         streamParser.on("end", function() {
+            graph.setEdges(edges);
             graph.connectEdges();
             resolve(graph);
         });

--- a/src/js/graph/parsers/graphParserXml.js
+++ b/src/js/graph/parsers/graphParserXml.js
@@ -3,6 +3,7 @@ var sax = require("sax");
 // var print = require("util").print;
 var Graph = require('../graph');
 var Node = require('../node');
+var Edge = require('../edge');
 
 function GraphParserXml() { }
 // @desc Take a stream and returns a promise. Once resolved the promise will hand off a Graph instance.
@@ -131,13 +132,7 @@ GraphParserXml.prototype.parse = function(readableStream) {
                     if (node) {
                         try {
                             var eAttrs = tag.attributes;
-                            edges.push({
-                                sourceId: node.getId(),
-                                targetId: eAttrs.to.value,
-                                type: eAttrs.type.value,
-                                toType: eAttrs.toType.value
-                            });
-                            // node.addEdge(eAttrs.to.value, eAttrs.toType.value, eAttrs.type.value, false);
+                            edges.push(new Edge(node.getId(), eAttrs.to.value, eAttrs.toType.value, eAttrs.type.value));
                         } catch (err) {
                             reject(new Error("Failed to parse edge for node `" + node.id + "`. [" + err + "]"));
                         }

--- a/src/js/graph/serializers/graphSerializerXml.js
+++ b/src/js/graph/serializers/graphSerializerXml.js
@@ -42,7 +42,7 @@ GraphSerializerXml.prototype.serializeNode = function(node) {
         }
     });
     node.getEdges().forEach(function(edge) {
-        lines.push(TAB+TAB + '<edge toType="' + es(edge.getTargetType()) + '" to="' + es(edge.getTargetId()) + '" type="' + es(edge.getEdgeType()) + '"/>');
+        lines.push(TAB+TAB + '<edge toType="' + es(edge.getTargetType()) + '" to="' + es(edge.getTargetId()) + '" type="' + es(edge.getType()) + '"/>');
     });
     lines.push(TAB + '</node>');
     return lines.join("\n");

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -49,7 +49,7 @@ function deepClone(o) {
 function logEdgeError(graph, sourceId, targetId, edgeType) {
     var message;
 
-    if (!graph.getNodeById(sourceId) && !graph.getNodeById(targetId)) {
+    if (!graph.nodeExists(sourceId) && !graph.nodeExists(targetId)) {
         message = [
             'Cannot create `',
             edgeType,
@@ -59,7 +59,7 @@ function logEdgeError(graph, sourceId, targetId, edgeType) {
             targetId,
             '`.'
         ].join('');
-    } else if (!graph.getNodeById(sourceId)) {
+    } else if (!graph.nodeExists(sourceId)) {
         message = [
             'Cannot create `',
             edgeType,
@@ -69,7 +69,7 @@ function logEdgeError(graph, sourceId, targetId, edgeType) {
             targetId,
             '`.'
         ].join('');
-    } else if (!graph.getNodeById(targetId)) {
+    } else if (!graph.nodeExists(targetId)) {
         message = [
             'Cannot create `',
             edgeType,

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -3,25 +3,25 @@ function StringBuilder() {
 
 	var verify = function (string) {
 		if (!defined(string)) {
-			return "";
+			return '';
 		}
-		if (getType(string) != getType("")) {
+		if (getType(string) != getType('')) {
 			return String(string);
 		}
 		return string;
 	};
 
 	var defined = function (el) {
-		return el !== null && typeof(el) != "undefined";
+		return el !== null && typeof el !== 'undefined';
 	};
 
 	var getType = function (instance) {
 		if (!defined(instance.constructor)) {
-			throw Error("Unexpected object type");
+			throw Error('Unexpected object type');
 		}
 		var type = String(instance.constructor).match(/function\s+(\w+)/);
 
-		return defined(type) ? type[1] : "undefined";
+		return defined(type) ? type[1] : 'undefined';
 	};
 
 	this.append = function (string) {
@@ -33,7 +33,7 @@ function StringBuilder() {
 	};
 
 	this.toString = function() {
-		return strings.join("");
+		return strings.join('');
 	};
 }
 
@@ -46,6 +46,46 @@ function deepClone(o) {
     return JSON.parse(JSON.stringify(o));
 }
 
+function logEdgeError(graph, sourceId, targetId, edgeType) {
+    var message;
+
+    if (!graph.getNodeById(sourceId) && !graph.getNodeById(targetId)) {
+        message = [
+            'Cannot create `',
+            edgeType,
+            '` edge between non-existent node ids `',
+            sourceId,
+            '` and `',
+            targetId,
+            '`.'
+        ].join('');
+    } else if (!graph.getNodeById(sourceId)) {
+        message = [
+            'Cannot create `',
+            edgeType,
+            '` edge from non-existent node id `',
+            sourceId,
+            '` to node id `',
+            targetId,
+            '`.'
+        ].join('');
+    } else if (!graph.getNodeById(targetId)) {
+        message = [
+            'Cannot create `',
+            edgeType,
+            '` edge from node id `',
+            sourceId,
+            '` to non-existent node id `',
+            targetId,
+            '`.'
+        ].join('');
+    }
+
+    if (message) { console.warn(message); }
+    return message;
+}
+
 module.exports.StringBuilder = StringBuilder;
 module.exports.doFreeze = doFreeze;
 module.exports.deepClone = deepClone;
+module.exports.logEdgeError = logEdgeError;

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -1,27 +1,27 @@
 function StringBuilder() {
 	var strings = [];
 
+    var defined = function (el) {
+        return el !== null && typeof el !== 'undefined';
+    };
+
+    var getType = function (instance) {
+        if (!defined(instance.constructor)) {
+            throw Error('Unexpected object type');
+        }
+        var type = String(instance.constructor).match(/function\s+(\w+)/);
+
+        return defined(type) ? type[1] : 'undefined';
+    };
+
 	var verify = function (string) {
 		if (!defined(string)) {
 			return '';
 		}
-		if (getType(string) != getType('')) {
+		if (getType(string) !== getType('')) {
 			return String(string);
 		}
 		return string;
-	};
-
-	var defined = function (el) {
-		return el !== null && typeof el !== 'undefined';
-	};
-
-	var getType = function (instance) {
-		if (!defined(instance.constructor)) {
-			throw Error('Unexpected object type');
-		}
-		var type = String(instance.constructor).match(/function\s+(\w+)/);
-
-		return defined(type) ? type[1] : 'undefined';
 	};
 
 	this.append = function (string) {
@@ -48,35 +48,37 @@ function deepClone(o) {
 
 function logEdgeError(graph, sourceId, targetId, edgeType) {
     var message;
-
+    function forceString(input) {
+        return '' + input;
+    }
     if (!graph.nodeExists(sourceId) && !graph.nodeExists(targetId)) {
         message = [
             'Cannot create `',
-            edgeType,
+            forceString(edgeType),
             '` edge between non-existent node ids `',
-            sourceId,
+            forceString(sourceId),
             '` and `',
-            targetId,
+            forceString(targetId),
             '`.'
         ].join('');
     } else if (!graph.nodeExists(sourceId)) {
         message = [
             'Cannot create `',
-            edgeType,
+            forceString(edgeType),
             '` edge from non-existent node id `',
-            sourceId,
+            forceString(sourceId),
             '` to node id `',
-            targetId,
+            forceString(targetId),
             '`.'
         ].join('');
     } else if (!graph.nodeExists(targetId)) {
         message = [
             'Cannot create `',
-            edgeType,
+            forceString(edgeType),
             '` edge from node id `',
-            sourceId,
+            forceString(sourceId),
             '` to non-existent node id `',
-            targetId,
+            forceString(targetId),
             '`.'
         ].join('');
     }

--- a/src/js/validator/index.js
+++ b/src/js/validator/index.js
@@ -6,13 +6,14 @@ var validationError = require('./validation-error');
 function validateNode(id, graph, schema) {
   var errors = [];
   var node = graph.getNodeById(id);
-  var nodeSpec = schema.nodeTypeMap[node.getType()];
-  var customError = validationError.createTemplate(id, node.getType());
+  var nodeType = node ? node.getType() : undefined;
+  var nodeSpec = schema.nodeTypeMap[nodeType];
+  var customError = validationError.createTemplate(id, nodeType);
 
   if (node && nodeSpec) {
     errors = nodeValidator(node, graph, nodeSpec, customError);
   } else if (!node) {
-    errors.push(customError(id, ['Node with id', id, 'does not exist'].join(' ')));
+    errors.push(customError(['Node with id', id, 'does not exist'].join(' ')));
   } else {
     errors.push(customError([node.getType(), 'is not defined in', schema.id].join(' ')));
   }

--- a/src/js/validator/validators/edge.js
+++ b/src/js/validator/validators/edge.js
@@ -17,7 +17,7 @@ function validateTarget(edge, edgeSpec, graph) {
     errors.push(validationError([
       targetNode.getType(),
       'is an invalid target for edge type:',
-      edge.getEdgeType()
+      edge.getType()
     ].join(' ')));
   }
 
@@ -31,7 +31,7 @@ function validate(edge, edgeSpec, graph) {
     errors.push.apply(errors, validateTarget(edge, edgeSpec, graph));
   } else {
     errors.push(validationError([
-        edge.getEdgeType(),
+        edge.getType(),
         'edge points to non-existent target with id:',
         edge.getTargetId()
       ].join(' '),

--- a/test/graph/graph-mary-manipulation-test.js
+++ b/test/graph/graph-mary-manipulation-test.js
@@ -58,28 +58,35 @@ describe('Graph manipulation for `mary` stream', function() {
             assert.equal(preAddTotalCount, graph.getNodes().length - 1);
             assert.equal(preAddTypeCount, graph.getNodesByType(node.getType()).length - 1);
         });
-        describe('sequence trait', function() {
-            beforeEach(createGraph);
-            beforeEach(function() { node = graph.createNode('TOK', '9000000'); });
+    });
+    describe('adding a node to the graph with a sequence trait', function() {
+        var node;
+        beforeEach(createGraph);
+        beforeEach(function() { node = graph.createNode('TOK', '9000000'); });
 
-            it('adding a first node', function() {
-                node.addEdge('24', 'next');
-                assert.equal(node.next(), graph.getNodeById('24'));
-                assert.equal(node.previous(), undefined);
-            });
-            it('adding a middle node', function() {
-                // console.log('24s next edge', graph.getNodeById('24').next()._id);
-                // console.log('83s prev edge', graph.getNodeById('83').previous()._id);
-                node.addEdge('83', 'next');
-                // console.log('Nodes next edge should be 83', node.next()._id);
-                assert.equal(node.previous(), graph.getNodeById('24'));
-                assert.equal(node.next(), graph.getNodeById('83'));
-            });
-            it('has access to it\'s parents', function() {
-                node.addEdge('83', 'next');
-                assert.equal(node.getFirstParentOfType('SB'), graph.getNodeById('68'));
-            });
+        it('adding a first node', function() {
+            node.addEdge('24', 'next');
+            assert.equal(node.next(), graph.getNodeById('24'));
+            assert.equal(node.previous(), undefined);
         });
+        it('adding a middle node', function() {
+            node.addEdge('83', 'next');
+
+            assert.equal(node.previous(), graph.getNodeById('24'));
+            assert.equal(node.next(), graph.getNodeById('83'));
+        });
+        it('adding a last node', function() {
+            var lastNodeInSequence = graph.getNodeById('78');
+            lastNodeInSequence.addEdge('9000000', 'next');
+
+            assert.equal(lastNodeInSequence.next(), node);
+            assert.equal(node.next(), undefined);
+        });
+        it('has access to it\'s parents', function() {
+            node.addEdge('83', 'next');
+            assert.equal(node.getFirstParentOfType('SB'), graph.getNodeById('68'));
+        });
+
     });
     describe('adding an edge to a node', function() {
         var node;

--- a/test/graph/graph-mary-manipulation-test.js
+++ b/test/graph/graph-mary-manipulation-test.js
@@ -72,9 +72,6 @@ describe('Graph manipulation for `mary` stream', function() {
                 assert.equal(node.previous(), graph.getNodeById('24'));
                 assert.equal(node.next(), graph.getNodeById('83'));
             });
-            it('adding a last node', function() {
-                // Not sure this is possible.
-            });
             it('has access to it\'s parents', function() {
                 node.setType('TOK');
                 node.addEdge('83', 'TOK', 'next');

--- a/test/graph/graph-mary-manipulation-test.js
+++ b/test/graph/graph-mary-manipulation-test.js
@@ -17,18 +17,18 @@ describe('Graph manipulation for `mary` stream', function() {
 
     describe('graph functions for manipulation', function() {
         it('can create new nodes', function() {
-            var node = graph.createNode();
+            var node = graph.createNode(null, 'TEST NODE');
             assert(node instanceof Node);
         });
     });
     describe('adding a node to the graph', function() {
         var node;
-        beforeEach(function() { node = graph.createNode(); });
+        beforeEach(function() { node = graph.createNode(null, 'TEST NODE'); });
 
         it('node must contain a type', function() {
             assert.throws(function() {
-                graph.addNode(node);
-            }, /must have a TYPE/);
+                graph.createNode();
+            }, /type is a required param/);
         });
         it('adding a node with the same id as another will error', function() {
             node.setId('1');
@@ -39,14 +39,13 @@ describe('Graph manipulation for `mary` stream', function() {
         });
         it('node without an id will get a generated id', function() {
             node.setType('TOK');
-            graph.addNode(node);
             // IDs should increment consecutively.
             assert.equal(node.getId(), (parseInt(graph._generateNodeId()) - 1).toString());
         });
         it('node will be added to the graph', function() {
             var preAddTotalCount = graph.getNodes().length;
             var preAddTypeCount = graph.getNodesByType('TOK').length;
-            node.setType('TOK');
+            node = new Node('900000', graph, 'TOK');
             graph.addNode(node);
             assert.equal(node, graph.getNodeById(node.getId()));
             assert.equal(preAddTotalCount, graph.getNodes().length - 1);
@@ -56,7 +55,6 @@ describe('Graph manipulation for `mary` stream', function() {
             it('adding a first node', function() {
                 node.setType('TOK');
                 node.addEdge('24', 'TOK', 'next');
-                graph.addNode(node);
                 assert.equal(node.next(), graph.getNodeById('24'));
             });
             it('adding a middle node', function() {
@@ -80,9 +78,7 @@ describe('Graph manipulation for `mary` stream', function() {
     describe('adding an edge to a node', function() {
         var node;
         beforeEach(function() {
-            node = graph.createNode();
-            node.setType('TOK');
-            graph.addNode(node);
+            node = graph.createNode(null, 'TOK');
         });
 
         it('creates the edge', function() {

--- a/test/graph/graph-mary-manipulation-test.js
+++ b/test/graph/graph-mary-manipulation-test.js
@@ -58,7 +58,7 @@ describe('Graph manipulation for `mary` stream', function() {
             assert.equal(preAddTotalCount, graph.getNodes().length - 1);
             assert.equal(preAddTypeCount, graph.getNodesByType(node.getType()).length - 1);
         });
-        describe.only('sequence trait', function() {
+        describe('sequence trait', function() {
             beforeEach(createGraph);
             beforeEach(function() { node = graph.createNode('TOK', '9000000'); });
 
@@ -77,7 +77,6 @@ describe('Graph manipulation for `mary` stream', function() {
             });
             it('has access to it\'s parents', function() {
                 node.addEdge('83', 'next');
-                graph.addNode(node);
                 assert.equal(node.getFirstParentOfType('SB'), graph.getNodeById('68'));
             });
         });
@@ -92,9 +91,10 @@ describe('Graph manipulation for `mary` stream', function() {
         it('creates the edge', function() {
             node.addEdge('2', 'arbitrary-edge', 'TOK');
             var edge = node.getFirstEdgeByType('arbitrary-edge');
+            assert.equal(node.getId(), edge.getSourceId());
             assert.equal(edge.getTargetId(), '2');
             assert.equal(edge.getTargetType(), 'TOK');
-            assert.equal(edge.getEdgeType(), 'arbitrary-edge');
+            assert.equal(edge.getType(), 'arbitrary-edge');
         });
     });
     describe('removing a node from a graph', function() {

--- a/test/graph/graph-mary-manipulation-test.js
+++ b/test/graph/graph-mary-manipulation-test.js
@@ -8,22 +8,29 @@ var maryStream = testStreams.fullList.filter(function(stream) {
 
 describe('Graph manipulation for `mary` stream', function() {
     var graph;
-    beforeEach(function(done) {
+    function createGraph(done) {
         Pagi.parse(maryStream.getXmlStream()).then(function(aGraph) {
             graph = aGraph;
             done();
         });
-    });
+    }
 
     describe('graph functions for manipulation', function() {
+        beforeEach(createGraph);
+
         it('can create new nodes', function() {
-            var node = graph.createNode(null, 'TEST NODE');
+            var node = graph.createNode('TEST NODE');
             assert(node instanceof Node);
+            assert.equal(node.getType(), 'TEST NODE');
+            assert.ok(node.getId());
+            assert.strictEqual(node._graph, graph);
         });
     });
+
     describe('adding a node to the graph', function() {
         var node;
-        beforeEach(function() { node = graph.createNode(null, 'TEST NODE'); });
+        beforeEach(createGraph);
+        beforeEach(function() { node = graph.createNode('TEST NODE'); });
 
         it('node must contain a type', function() {
             assert.throws(function() {
@@ -51,16 +58,17 @@ describe('Graph manipulation for `mary` stream', function() {
             assert.equal(preAddTotalCount, graph.getNodes().length - 1);
             assert.equal(preAddTypeCount, graph.getNodesByType(node.getType()).length - 1);
         });
-        describe('sequence trait', function() {
+        describe.only('sequence trait', function() {
+            beforeEach(createGraph);
+            beforeEach(function() { node = graph.createNode('TOK'); });
+
             it('adding a first node', function() {
-                node.setType('TOK');
-                node.addEdge('24', 'TOK', 'next');
+                node.addEdge('24', 'next');
                 assert.equal(node.next(), graph.getNodeById('24'));
+                assert.equal(node.previous(), undefined);
             });
             it('adding a middle node', function() {
-                node.setType('TOK');
                 node.addEdge('83', 'TOK', 'next');
-                graph.addNode(node);
                 assert.equal(node.previous(), graph.getNodeById('24'));
                 assert.equal(node.next(), graph.getNodeById('83'));
             });
@@ -77,12 +85,13 @@ describe('Graph manipulation for `mary` stream', function() {
     });
     describe('adding an edge to a node', function() {
         var node;
+        beforeEach(createGraph);
         beforeEach(function() {
-            node = graph.createNode(null, 'TOK');
+            node = graph.createNode('TOK');
         });
 
         it('creates the edge', function() {
-            node.addEdge('2', 'TOK', 'arbitrary-edge');
+            node.addEdge('2', 'arbitrary-edge', 'TOK');
             var edge = node.getFirstEdgeByType('arbitrary-edge');
             assert.equal(edge.getTargetId(), '2');
             assert.equal(edge.getTargetType(), 'TOK');
@@ -91,6 +100,7 @@ describe('Graph manipulation for `mary` stream', function() {
     });
     describe('removing a node from a graph', function() {
         var node, prevNode, nextNode, nodeTotalCnt, nodeTypeCnt;
+        beforeEach(createGraph);
         beforeEach(function() {
             node = graph.getNodeById('2');
             prevNode = node.previous();
@@ -120,6 +130,7 @@ describe('Graph manipulation for `mary` stream', function() {
     });
     describe('removing an edge from a node', function() {
         var node;
+        beforeEach(createGraph);
         beforeEach(function() {
             node = graph.getNodeById('2');
             var nextEdge = node.getFirstEdgeByType('next');

--- a/test/graph/graph-mary-manipulation-test.js
+++ b/test/graph/graph-mary-manipulation-test.js
@@ -60,7 +60,7 @@ describe('Graph manipulation for `mary` stream', function() {
         });
         describe.only('sequence trait', function() {
             beforeEach(createGraph);
-            beforeEach(function() { node = graph.createNode('TOK'); });
+            beforeEach(function() { node = graph.createNode('TOK', '9000000'); });
 
             it('adding a first node', function() {
                 node.addEdge('24', 'next');
@@ -68,13 +68,15 @@ describe('Graph manipulation for `mary` stream', function() {
                 assert.equal(node.previous(), undefined);
             });
             it('adding a middle node', function() {
-                node.addEdge('83', 'TOK', 'next');
+                // console.log('24s next edge', graph.getNodeById('24').next()._id);
+                // console.log('83s prev edge', graph.getNodeById('83').previous()._id);
+                node.addEdge('83', 'next');
+                // console.log('Nodes next edge should be 83', node.next()._id);
                 assert.equal(node.previous(), graph.getNodeById('24'));
                 assert.equal(node.next(), graph.getNodeById('83'));
             });
             it('has access to it\'s parents', function() {
-                node.setType('TOK');
-                node.addEdge('83', 'TOK', 'next');
+                node.addEdge('83', 'next');
                 graph.addNode(node);
                 assert.equal(node.getFirstParentOfType('SB'), graph.getNodeById('68'));
             });

--- a/test/graph/graphSerializer-test.js
+++ b/test/graph/graphSerializer-test.js
@@ -44,11 +44,11 @@ describe('GraphSerializer', function() {
             } else {
                 it('matches the xml file', function() {
                     var preSerialized = GraphSerializer.serialize(graph);
-                    // fs.writeFileSync('/tmp/pre-serialize-' + stream.name + '.xml', preSerialized);
+                    fs.writeFileSync('/tmp/pre-serialize-' + stream.name + '.xml', preSerialized);
                     var serialized = PAGI_XSLT.apply(preSerialized);
-                    // fs.writeFileSync('/tmp/serialize-' + stream.name + '.xml', serialized);
+                    fs.writeFileSync('/tmp/serialize-' + stream.name + '.xml', serialized);
                     var gold = PAGI_XSLT.apply(stream.getXml());
-                    // fs.writeFileSync('/tmp/serialize-' + stream.name + '-gold.xml', gold);
+                    fs.writeFileSync('/tmp/serialize-' + stream.name + '-gold.xml', gold);
                     assert.equal(serialized, gold);
                 });
             }

--- a/test/graph/graphSerializer-test.js
+++ b/test/graph/graphSerializer-test.js
@@ -44,11 +44,11 @@ describe('GraphSerializer', function() {
             } else {
                 it('matches the xml file', function() {
                     var preSerialized = GraphSerializer.serialize(graph);
-                    fs.writeFileSync('/tmp/pre-serialize-' + stream.name + '.xml', preSerialized);
+                    // fs.writeFileSync('/tmp/pre-serialize-' + stream.name + '.xml', preSerialized);
                     var serialized = PAGI_XSLT.apply(preSerialized);
-                    fs.writeFileSync('/tmp/serialize-' + stream.name + '.xml', serialized);
+                    // fs.writeFileSync('/tmp/serialize-' + stream.name + '.xml', serialized);
                     var gold = PAGI_XSLT.apply(stream.getXml());
-                    fs.writeFileSync('/tmp/serialize-' + stream.name + '-gold.xml', gold);
+                    // fs.writeFileSync('/tmp/serialize-' + stream.name + '-gold.xml', gold);
                     assert.equal(serialized, gold);
                 });
             }

--- a/test/validator/graph-validator-test.js
+++ b/test/validator/graph-validator-test.js
@@ -51,6 +51,16 @@ describe('validator validateGraph', function() {
     assert(results.errors.length === 0);
   });
 
+  it('should validate node existence', function() {
+    marryGraph._graphImpl.setNode('900000', undefined);
+
+    var results = validator.validateGraph(marryGraph, marryschema);
+
+    assert.equal(results.isValid, false);
+    assert.equal(results.errors.length, 1);
+    assert.equal(results.errors[0].message, 'Node with id 900000 does not exist');
+  });
+
   it('should validate min arity', function() {
     var node = marryGraph.getNodeById('0');
     delete node._properties.start;
@@ -59,8 +69,8 @@ describe('validator validateGraph', function() {
     var results = validator.validateGraph(marryGraph, marryschema);
 
     assert.equal(results.isValid, false);
-    assert(results.errors.length === 1);
-    assert(results.errors[0].message === 'start is a required property');
+    assert.equal(results.errors.length, 1);
+    assert.equal(results.errors[0].message, 'start is a required property');
   });
 
   it('should validate max arity', function() {
@@ -71,8 +81,8 @@ describe('validator validateGraph', function() {
     var results = validator.validateGraph(marryGraph, marryschema);
 
     assert.equal(results.isValid, false);
-    assert(results.errors.length === 1);
-    assert(results.errors[0].message === 'Arity of start property is out of range. Arity min: 1 Arity max: 1 Arity Actual: 2');
+    assert.equal(results.errors.length, 1);
+    assert.equal(results.errors[0].message, 'Arity of start property is out of range. Arity min: 1 Arity max: 1 Arity Actual: 2');
   });
 
   it('should validate intProps', function() {
@@ -83,7 +93,7 @@ describe('validator validateGraph', function() {
     var results = validator.validateGraph(marryGraph, marryschema);
 
     assert.equal(results.isValid, false);
-    assert(results.errors.length === 2);
+    assert.equal(results.errors.length, 2);
     assert.equal(results.errors[0].message, 'start must be an integer');
     assert.equal(results.errors[1].message, 'start must be within 0 and 2147483647');
   });
@@ -96,7 +106,7 @@ describe('validator validateGraph', function() {
     var results = validator.validateGraph(marryGraph, marryschema);
 
     assert.equal(results.isValid, false);
-    assert(results.errors.length === 2);
+    assert.equal(results.errors.length, 2);
     assert.equal(results.errors[0].message, 'start must be an integer');
     assert.equal(results.errors[1].message, 'start must be within 0 and 2147483647');
   });
@@ -109,7 +119,7 @@ describe('validator validateGraph', function() {
     var results = validator.validateGraph(marryGraph, marryschema);
 
     assert.equal(results.isValid, false);
-    assert(results.errors.length === 1);
+    assert.equal(results.errors.length, 1);
     assert.equal(results.errors[0].message, 'start must be an integer');
   });
 
@@ -121,7 +131,7 @@ describe('validator validateGraph', function() {
     var results = validator.validateGraph(marryGraph, marryschema);
 
     assert.equal(results.isValid, false);
-    assert(results.errors.length === 2);
+    assert.equal(results.errors.length, 2);
     assert.equal(results.errors[0].message, 'pos must be a string');
     assert.equal(results.errors[1].message, '5 is not a valid value for property pos');
   });
@@ -134,7 +144,7 @@ describe('validator validateGraph', function() {
     var results = validator.validateGraph(testDoc2Graph, testDoc2Schema);
 
     assert.equal(results.isValid, false);
-    assert(results.errors.length === 2);
+    assert.equal(results.errors.length, 2);
     assert.equal(results.errors[0].message, 'precision must be a float');
     assert.equal(results.errors[1].message, 'precision must be within 0 and 1');
   });
@@ -147,7 +157,7 @@ describe('validator validateGraph', function() {
     var results = validator.validateGraph(testDoc2Graph, testDoc2Schema);
 
     assert.equal(results.isValid, false);
-    assert(results.errors.length === 1);
+    assert.equal(results.errors.length, 1);
     assert.equal(results.errors[0].message, 'enabled must be a boolean');
   });
 
@@ -159,29 +169,29 @@ describe('validator validateGraph', function() {
     var results = validator.validateGraph(marryGraph, marryschema);
 
     assert.equal(results.isValid, false);
-    assert(results.errors.length === 1);
+    assert.equal(results.errors.length, 1);
     assert.equal(results.errors[0].message, 'member is a required edge');
   });
 
-  it('should validate target Edge existence', function() {
-    marryGraph._graphImpl.removeNode('8');
+  it('should validate Edge target existence', function() {
+    marryGraph._graphImpl.setNode('8', undefined);
 
     var results = validator.validateGraph(marryGraph, marryschema);
 
     assert.equal(results.isValid, false);
-    assert(results.errors.length === 3);
+    assert.equal(results.errors.length, 4);
     assert.equal(results.errors[0].message, 'member edge points to non-existent target with id: 8');
   });
 
-  it('should validate target Edge type', function() {
+  it('should validate Edge target type', function() {
     var node = marryGraph.getNodeById('7');
-    node.addEdge('10', 'TOK', 'member');
+    node.addEdge('10', 'member', 'TOK');
     marryGraph._graphImpl.setNode('7', node);
 
     var results = validator.validateGraph(marryGraph, marryschema);
 
     assert.equal(results.isValid, false);
-    assert(results.errors.length === 1);
+    assert.equal(results.errors.length, 1);
     assert.equal(results.errors[0].message, 'COREF is an invalid target for edge type: member');
   });
 });


### PR DESCRIPTION
Overview
NOTE: DO NOT MERGE THIS PR UNTIL A CORRESPONDING NAUT TICKET HAS BEEN CREATED

This ticket refactors pagijs to only store edges in the graphlib implementation instead of as separate objects in an array. This has multiple consequences to how we manipulate graphs:
1. When calling graph.createNode(), you MUST pass in a type and may optionally pass in an id. The object returned is a node that has ALREADY been added to the graph, and if no id was passed in given a generated id
2. Deleting a node from the graph deletes all edges that pointed to it

Testing
Insure tests all pass (run `npm test`.

Points of interest:
Review next / previous function changes in graph/node.js and sequence /span container linking in general. This is a large change from what we had before (always assumed only one next edge to any given node) and might cause issues I'm not aware of at the moment. We can refactor if needed
