### PR TITLE
Feature/pagi 176 readable names in error messages

### DIFF
--- a/src/js/validator/index.js
+++ b/src/js/validator/index.js
@@ -2,6 +2,7 @@
 
 var nodeValidator = require('./validators/node');
 var validationError = require('./validation-error');
+var readableNameUtil = require('./name-util');
 
 function validateNode(id, graph, schema) {
   var errors = [];
@@ -9,6 +10,7 @@ function validateNode(id, graph, schema) {
   var nodeType = node ? node.getType() : undefined;
   var nodeSpec = schema.nodeTypeMap[nodeType];
   var customError = validationError.createTemplate(id, nodeType);
+  readableNameUtil.setNames(schema.nodeTypeMap);
 
   if (node && nodeSpec) {
     errors = nodeValidator(node, graph, nodeSpec, customError);
@@ -17,6 +19,8 @@ function validateNode(id, graph, schema) {
   } else {
     errors.push(customError([node.getType(), 'is not defined in', schema.id].join(' ')));
   }
+
+  readableNameUtil.unsetNames();
 
   var isValid = (errors.length === 0);
   return {

--- a/src/js/validator/name-util.js
+++ b/src/js/validator/name-util.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var nameMap = null;
+
+module.exports.setNames = setNames;
+module.exports.unsetNames = unsetNames;
+module.exports.getReadableName = getReadableName;
+module.exports.parseName = parseName;
+
+function setNames(nodeTypeMap) {
+  nameMap = nodeTypeMap;
+}
+
+function unsetNames() {
+  nameMap = null;
+}
+
+function getReadableName(name) {
+  var readableName = nameMap[name].readableName || name;
+  return readableName;
+}
+
+function parseName(spec) {
+  var name = spec.readableName || spec.name;
+  return name;
+}

--- a/src/js/validator/validators/edge.js
+++ b/src/js/validator/validators/edge.js
@@ -3,6 +3,7 @@
 var validationError = null;
 var validateArity = require('./validation-utils').validateArity;
 var isRequired = require('./validation-utils').isRequired;
+var nameUtil = require('./../name-util');
 
 function targetExists(id, graph) {
   return !!graph.getNodeById(id);
@@ -11,11 +12,11 @@ function targetExists(id, graph) {
 function validateTarget(edge, edgeSpec, graph) {
   var errors = [];
   var targetNode = graph.getNodeById(edge.getTargetId());
-  var invalidTarget = edgeSpec.targetNodeTypes.indexOf(targetNode.getType()) === -1;
+  var isInvalidTarget = edgeSpec.targetNodeTypes.indexOf(targetNode.getType()) === -1;
 
-  if (invalidTarget) {
+  if (isInvalidTarget) {
     errors.push(validationError([
-      targetNode.getType(),
+      nameUtil.getReadableName(targetNode.getType()),
       'is an invalid target for edge type:',
       edge.getType()
     ].join(' ')));

--- a/src/js/validator/validators/property.js
+++ b/src/js/validator/validators/property.js
@@ -2,6 +2,7 @@
 
 var validateArity = require('./validation-utils').validateArity;
 var isRequired = require('./validation-utils').isRequired;
+var parseName = require('./../name-util').parseName;
 var validationError = null;
 
 function isOutOfRange(value, range) {
@@ -17,12 +18,12 @@ function validateIntProp(prop, propSpec) {
 
   prop.vals.forEach(function(val) {
     if (!isInteger(val)) {
-      errors.push(validationError([propSpec.name, 'must be an integer'].join(' ')));
+      errors.push(validationError([parseName(propSpec), 'must be an integer'].join(' ')));
     }
 
     if (isOutOfRange(val, propSpec.restrictions)) {
       errors.push(validationError([
-        propSpec.name,
+        parseName(propSpec),
         'must be within',
         propSpec.restrictions.minRange,
         'and',
@@ -39,12 +40,12 @@ function validateFloatProp(prop, propSpec) {
 
   prop.vals.forEach(function(val) {
     if (typeof val !== 'number') {
-      errors.push(validationError([propSpec.name, 'must be a float'].join(' ')));
+      errors.push(validationError([parseName(propSpec), 'must be a float'].join(' ')));
     }
 
     if (isOutOfRange(val, propSpec.restrictions)) {
       errors.push(validationError([
-        propSpec.name,
+        parseName(propSpec),
         'must be within',
         propSpec.restrictions.minRange,
         'and',
@@ -77,7 +78,7 @@ function validateStringProp(prop, propSpec) {
 
   prop.vals.forEach(function(val) {
     if (typeof val !== 'string') {
-      errors.push(validationError([propSpec.name, 'must be a string'].join(' ')));
+      errors.push(validationError([parseName(propSpec), 'must be a string'].join(' ')));
     }
   });
 
@@ -93,7 +94,7 @@ function validateBoolProp(prop, propSpec) {
 
   prop.vals.forEach(function(val) {
     if (typeof val !== 'boolean') {
-      errors.push(validationError([propSpec.name, 'must be a boolean'].join(' ')));
+      errors.push(validationError([parseName(propSpec), 'must be a boolean'].join(' ')));
     }
   });
 
@@ -131,7 +132,7 @@ module.exports = function validateProperties(node, nodeSpec, customErr) {
           throw new Error('Schema valueType ' + propSpec.valueType.name + ' not a valid type.');
       }
     } else if (isRequired(propSpec)) {
-      errors.push(validationError([propSpec.name, 'is a required property'].join(' ')));
+      errors.push(validationError([parseName(propSpec), 'is a required property'].join(' ')));
     }
 
   });

--- a/src/js/validator/validators/validation-utils.js
+++ b/src/js/validator/validators/validation-utils.js
@@ -2,7 +2,10 @@
 
 var constants = require('../../schema/constants');
 
-module.exports.validateArity = function validateArity(objs, spec, customErr) {
+module.exports.validateArity = validateArity;
+module.exports.isRequired = isRequired;
+
+function validateArity(objs, spec, customErr) {
   var errors = [];
   if (spec.maxArity === constants.UNBOUNDED_ARITY) { return errors; }
 
@@ -20,8 +23,8 @@ module.exports.validateArity = function validateArity(objs, spec, customErr) {
   }
 
   return errors;
-};
+}
 
-module.exports.isRequired = function isRequired(spec) {
+function isRequired(spec) {
   return ( spec.minArity > 0 );
-};
+}

--- a/test/test-suite/schema/def/extTokCorefSchema.xml
+++ b/test/test-suite/schema/def/extTokCorefSchema.xml
@@ -2,7 +2,7 @@
 <pagis xmlns="http://pagi.org/schema" id="http://pagi.org/testSuite/extTokCoref">
 	<extends id="http://pagi.org/testSuite/simpleTok"/>
 
-	<nodeType name="COREF">
+	<nodeType name="COREF" readableName="Co-Reference">
 		<stringProperty name="name"/>
 		<edgeType name="member" targetNodeType="TOK" minArity="1" targetMinArity="0" targetMaxArity="1"/>
 	</nodeType>

--- a/test/test-suite/schema/flat/extTokCorefSchema.txt
+++ b/test/test-suite/schema/flat/extTokCorefSchema.txt
@@ -1,7 +1,7 @@
 http://pagi.org/testSuite/extTokCoref
 EXTENDS http://pagi.org/testSuite/simpleTok
 
-NODETYPE COREF
+NODETYPE COREF Co-Reference
 PROP name 0 0 UNBOUNDED STRING
 EDGE member 1 UNBOUNDED 0 1 TOK
 

--- a/test/test-suite/schema/flat/extTokFullSchema.txt
+++ b/test/test-suite/schema/flat/extTokFullSchema.txt
@@ -2,7 +2,7 @@ http://pagi.org/testSuite/extTokFull
 EXTENDS http://pagi.org/testSuite/extTok
 EXTENDS http://pagi.org/testSuite/extTokCoref
 
-NODETYPE COREF
+NODETYPE COREF Co-Reference
 PROP name 0 0 UNBOUNDED STRING
 EDGE member 1 UNBOUNDED 0 1 TOK
 

--- a/test/validator/graph-validator-test.js
+++ b/test/validator/graph-validator-test.js
@@ -192,6 +192,6 @@ describe('validator validateGraph', function() {
 
     assert.equal(results.isValid, false);
     assert.equal(results.errors.length, 1);
-    assert.equal(results.errors[0].message, 'COREF is an invalid target for edge type: member');
+    assert.equal(results.errors[0].message, 'Co-Reference is an invalid target for edge type: member');
   });
 });


### PR DESCRIPTION
Overview
Adds utilities to populate error messages with annotation readable names instead of just name.

Testing
Run `npm test`, ensure everything passes. The functionality is directly tested by changes to the test schemas and the "should validate Edge target type" test
