### PR TITLE
corrected method name for error logging

### DIFF
--- a/src/js/graph/graph.js
+++ b/src/js/graph/graph.js
@@ -132,7 +132,7 @@ Graph.prototype.edgeExists = function(sourceId, targetId, edgeType) {
 };
 Graph.prototype._addEdge = function(sourceId, targetId, edgeType, toType) {
     if (!this.nodeExists(sourceId) || !this.nodeExists(targetId)) {
-        return utils.logEdgeTargetError(this, sourceId, targetId, edgeType);
+        return utils.logEdgeError(this, sourceId, targetId, edgeType);
     }
 
     toType = toType || this.getNodeById(targetId).getType();


### PR DESCRIPTION
Overview
A merge conflict was fixe incorrectly in PAGI-170, and we ended up with the wrong method name for logging errors to the console.
