### PR TITLE
Feature/pagi 178 refactor inedge outedge

### DIFF
--- a/src/js/graph/graph.js
+++ b/src/js/graph/graph.js
@@ -143,16 +143,29 @@ Graph.prototype._addEdges = function(edges) {
     }, this);
 };
 Graph.prototype.getEdge = function(sourceId, targetId, edgeType) {
-    return this._graphImpl.edge(sourceId, targetId, edgeType);
+    var edge;
+
+    if (typeof sourceId === 'object') {
+        // source id is an edge object {v, w, name}
+        edge = this._graphImpl.edge(sourceId);
+    } else {
+        edge = this._graphImpl.edge(sourceId, targetId, edgeType);
+    }
+
+    return edge;
 };
 Graph.prototype._removeEdge = function(sourceId, targetId, edgeType) {
     this._graphImpl.removeEdge(sourceId, targetId, edgeType);
 };
 Graph.prototype.inEdges = function(sourceId, targetId) {
-    return this._graphImpl.inEdges(sourceId, targetId);
+    return this._graphImpl.inEdges(sourceId, targetId).map(function(libEdge) {
+        return this.getEdge(libEdge);
+    }, this);
 };
 Graph.prototype.outEdges = function(sourceId, targetId) {
-    return this._graphImpl.outEdges(sourceId, targetId);
+    return this._graphImpl.outEdges(sourceId, targetId).map(function(libEdge) {
+        return this.getEdge(libEdge);
+    }, this);
 };
 Graph.prototype.edgeExists = function(sourceId, targetId, type) {
     return this._graphImpl.hasEdge(sourceId, targetId, type);

--- a/src/js/graph/graph.js
+++ b/src/js/graph/graph.js
@@ -137,7 +137,7 @@ Graph.prototype._addEdge = function(sourceId, targetId, edgeType, toType) {
 
     this._graphImpl.setEdge(sourceId, targetId, newEdge, edgeType);
 };
-Graph.prototype._addEdges = function(edges) {
+Graph.prototype.addEdges = function(edges) {
     edges.forEach(function(edge) {
         this._addEdge(edge.getSourceId(), edge.getTargetId(), edge.getType(), edge.getTargetType());
     }, this);

--- a/src/js/graph/node.js
+++ b/src/js/graph/node.js
@@ -72,9 +72,7 @@ Node.prototype.addEdge = function(targetId, edgeType, targetType) {
     this._graph._addEdge(this.getId(), targetId, edgeType, targetType);
 };
 Node.prototype.getEdges = function() {
-    return this._graph.outEdges(this.getId()).map(function(edge) {
-        return this._graph.getEdge(edge.v, edge.w, edge.name);
-    }, this);
+    return this._graph.outEdges(this.getId());
 };
 Node.prototype.getEdgesByType = function(edgeType) {
     return this.getEdges().filter(function(edge) {
@@ -204,16 +202,16 @@ Node.prototype.previous = function(ids) {
 
     if (ids) {
         previousImplEdges = previousImplEdges.filter(function(edge) {
-            return ids.indexOf(edge.v) === -1;
+            return ids.indexOf(edge.getSourceId()) === -1;
         });
     }
 
     if (previousImplEdges.length < 1) { return undefined; }
-    return this._graph.getNodeById(previousImplEdges[0].v);
+    return this._graph.getNodeById(previousImplEdges[0].getSourceId());
 };
 Node.prototype._getEdgesImplByLabels = function(direction, labels)  {
-    return this._graph[direction + 'Edges'](this.getId()).filter(function(edgeImpl) {
-        return labels.indexOf(edgeImpl.name) !== -1;
+    return this._graph[direction + 'Edges'](this.getId()).filter(function(edge) {
+        return labels.indexOf(edge.getType()) !== -1;
     }, this._graph);
 };
 

--- a/src/js/graph/parsers/graphParserXml.js
+++ b/src/js/graph/parsers/graphParserXml.js
@@ -165,7 +165,7 @@ GraphParserXml.prototype.parse = function(readableStream) {
             }
         });
         streamParser.on("end", function() {
-            graph._addEdges(edges);
+            graph.addEdges(edges);
             resolve(graph);
         });
         streamParser.on("error", function(err) {


### PR DESCRIPTION
Overview
TEST WITH NAUT-72
Refactors the inEdge and outEdge methods to return Edge instances instead of graphlib edges

Testing
Ensure tests pass. 
