### PR TITLE
PAGI-180 added raw content cache for graph

### DIFF
--- a/src/js/graph/graph.js
+++ b/src/js/graph/graph.js
@@ -11,6 +11,7 @@ function Graph(id) {
     this._version = '2.0';
     this._schemaUris = [];
     this._content = null;
+    this._rawContent = null;
     this._contentType = null;
     this._spanNodeTypes = { };
     this._sequenceNodeTypes = { };
@@ -36,10 +37,15 @@ Graph.prototype.getSchemaUris = function() {
 Graph.prototype.setContent = function(content) {
     this._content = content;
 };
+Graph.prototype.setRawContent = function(rawContent) {
+    this._rawContent = rawContent;
+};
 Graph.prototype.getContent = function() {
     return this._content;
 };
-
+Graph.prototype.getRawContent = function() {
+    return this._rawContent;
+};
 Graph.prototype.setContentType = function(contentType) {
     this._contentType = contentType;
 };

--- a/src/js/graph/parsers/content-cache.js
+++ b/src/js/graph/parsers/content-cache.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var util = require('util');
+var Transform = require('stream').Transform;
+
+var CONTENT_OPEN_TAG = /<content[^>]*>/;
+var CONTENT_CLOSE_TAG = /<\/content>/;
+var CONTENT_CAPTURE = /<content[^>]*>([^<]*)<\/content>/;
+
+util.inherits(ContentCache, Transform);
+
+function ContentCache(options) {
+  if (!options || typeof options !== 'object') {
+    options = {};
+  }
+
+  if (!(this instanceof ContentCache)) {
+    return new ContentCache(options);
+  }
+
+  Transform.call(this, options);
+
+  this.buffer = '';
+  this.rawContent = '';
+}
+
+ContentCache.prototype._transform = function(chunk, encoding, done) {
+  var data;
+
+  if (this.buffer.length === 0 && this.rawContent.length === 0) {
+    data = chunk.toString();
+    if (data.match(CONTENT_OPEN_TAG) && data.match(CONTENT_CLOSE_TAG)) {
+      this.rawContent = data.match(CONTENT_CAPTURE)[1];
+    } else {
+      this.buffer += data;
+    }
+  } else if (this.buffer.length > 0 && this.rawContent.length === 0) {
+    this.buffer += chunk.toString();
+
+    if (this.buffer.match(CONTENT_OPEN_TAG) && this.buffer.match(CONTENT_CLOSE_TAG)) {
+      this.rawContent = this.buffer.match(CONTENT_CAPTURE)[1];
+      this.buffer = '';
+    }
+  }
+
+  done(null, chunk);
+};
+
+module.exports = ContentCache;

--- a/src/js/graph/parsers/content-cache.js
+++ b/src/js/graph/parsers/content-cache.js
@@ -20,26 +20,32 @@ function ContentCache(options) {
 
   Transform.call(this, options);
 
+  this.waitingForContent = true;
   this.buffer = '';
-  this.rawContent = '';
 }
+
+ContentCache.prototype.done = function() {
+  this.waitingForContent = false;
+  this.buffer = '';
+};
 
 ContentCache.prototype._transform = function(chunk, encoding, done) {
   var data;
 
-  if (this.buffer.length === 0 && this.rawContent.length === 0) {
+  if (this.buffer.length === 0 && this.waitingForContent) {
     data = chunk.toString();
     if (data.match(CONTENT_OPEN_TAG) && data.match(CONTENT_CLOSE_TAG)) {
-      this.rawContent = data.match(CONTENT_CAPTURE)[1];
+      this.emit('content-parsed', data.match(CONTENT_CAPTURE)[1]);
+      this.done();
     } else {
       this.buffer += data;
     }
-  } else if (this.buffer.length > 0 && this.rawContent.length === 0) {
+  } else if (this.buffer.length > 0 && this.waitingForContent) {
     this.buffer += chunk.toString();
 
     if (this.buffer.match(CONTENT_OPEN_TAG) && this.buffer.match(CONTENT_CLOSE_TAG)) {
-      this.rawContent = this.buffer.match(CONTENT_CAPTURE)[1];
-      this.buffer = '';
+      this.emit('content-parsed', this.buffer.match(CONTENT_CAPTURE)[1]);
+      this.done();
     }
   }
 

--- a/src/js/graph/parsers/graphParser.js
+++ b/src/js/graph/parsers/graphParser.js
@@ -2,16 +2,19 @@
 //   Provides access to the different graph parsers available in the library.
 
 var GraphParserXml = require('../parsers/graphParserXml');
+var ContentCache = require('../parsers/content-cache');
 // var GraphParserFlat = require('./graphParserFlat');
 // var GraphParserBinary = require('./graphParserBinary');
 
 function parseXml(readableStream) {
-    return (new GraphParserXml()).parse(readableStream);
+    var cache = new ContentCache();
+    readableStream.pipe(cache);
+    return (new GraphParserXml()).parse(cache);
 }
-// function parseFlat(readableStream) { 
+// function parseFlat(readableStream) {
 //     return new GraphParserFlat(readableStream);
 // }
-// function parseBinary(readableStream) { 
+// function parseBinary(readableStream) {
 //     return new GraphParserBinary(readableStream);
 // }
 

--- a/src/js/graph/parsers/graphParserXml.js
+++ b/src/js/graph/parsers/graphParserXml.js
@@ -166,6 +166,7 @@ GraphParserXml.prototype.parse = function(readableStream) {
         });
         streamParser.on("end", function() {
             graph.addEdges(edges);
+            graph.setRawContent(readableStream.rawContent);
             resolve(graph);
         });
         streamParser.on("error", function(err) {

--- a/src/js/graph/parsers/graphParserXml.js
+++ b/src/js/graph/parsers/graphParserXml.js
@@ -166,13 +166,15 @@ GraphParserXml.prototype.parse = function(readableStream) {
         });
         streamParser.on("end", function() {
             graph.addEdges(edges);
-            graph.setRawContent(readableStream.rawContent);
             resolve(graph);
         });
         streamParser.on("error", function(err) {
             readableStream.pause();
             readableStream.unpipe(streamParser);
             reject(err);
+        });
+        readableStream.on('content-parsed', function(rawContent) {
+            graph.setRawContent(rawContent);
         });
         try {
             readableStream.pipe(streamParser);

--- a/src/js/graph/serializers/graphSerializerXml.js
+++ b/src/js/graph/serializers/graphSerializerXml.js
@@ -60,7 +60,7 @@ GraphSerializerXml.prototype.serialize = function(graph) {
     lines.push(this.serializeTrait(graph.getNodeTypesAsSpan(), 'asSpan'));
     lines.push(this.serializeTrait(graph.getNodeTypesAsSequence(), 'asSequence'));
     lines.push(this.serializeTrait(graph.getNodeTypesAsSpanContainer(), 'asSpanContainer'));
-    lines.push(TAB + '<content contentType="' + es(graph.getContentType()) + '">' + es(graph.getContent()) + '</content>');
+    lines.push(TAB + '<content contentType="' + es(graph.getContentType()) + '">' + graph.getRawContent() + '</content>');
     lines.push("");
     graph.getNodes().forEach(function(node) {
         lines.push(self.serializeNode(node));

--- a/test/fixtures/test-doc-with-cr.xml
+++ b/test/fixtures/test-doc-with-cr.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://pagi.org/stream" id="254_1242099976018.txt" version="2.0">
+<schema uri="http://digitalreasoning.com/pagi/docgraph-core"></schema>
+
+
+
+    <content contentType="message/rfc822">Date: Sun, 30 Nov 0002 00:00:00 -0800 (PST)&#13;
+Message-ID: &lt;K50FFLIEH5BFSU2IUMUOZMHFWJPLDGEEA@zlsvr22&gt;&#13;
+MIME-Version: 1.0&#13;
+Content-Type: text/plain; charset=us-ascii&#13;
+Content-Transfer-Encoding: 7bit&#13;
+to: Horton, Stanley &lt;/O=ENRON/OU=NA/CN=RECIPIENTS/CN=Shorton&gt;&#13;
+subject: Leaving!&#13;
+filename: brogers (Non-Privileged).pst&#13;
+folder: \Benjamin_Rogers_Mar2002\Rogers, Benjamin\Drafts&#13;
+date: Sun, 30 Nov 0002 00:00:00 -0800  (PST)&#13;
+&#13;
+Stan:&#13;
+Its been a very interesting ride these last four and a half years here.  I received an offer from UBS, but decided to turn it down for personal reasons.  These last few weeks I have been with the estate working on selling certain assets.  Tomorrow is my last day with the estate and then I am off to Ohio and Cinergy to continue trading but for Cinergy.  I will also begin to learn the oprations of Cinergy as well as go back and get an executive MBA at Chicago.  Ultimately, learn more about the overall operations and risk management.  I just wanted to thank you for all you have done while I have been here.  I look back and think that I should have spent time in the pipeline group.  Even after all that has happened I certainly wouldn't change what I have experienced.  Thanks again for being such a &#13;
+&#13;
+&#13;
+</content>
+
+</document>

--- a/test/fixtures/test-doc-with-xml-entities.xml
+++ b/test/fixtures/test-doc-with-xml-entities.xml
@@ -19,6 +19,24 @@ Stan:&#13;
 Its been a very interesting ride these last four and a half years here.  I received an offer from UBS, but decided to turn it down for personal reasons.  These last few weeks I have been with the estate working on selling certain assets.  Tomorrow is my last day with the estate and then I am off to Ohio and Cinergy to continue trading but for Cinergy.  I will also begin to learn the oprations of Cinergy as well as go back and get an executive MBA at Chicago.  Ultimately, learn more about the overall operations and risk management.  I just wanted to thank you for all you have done while I have been here.  I look back and think that I should have spent time in the pipeline group.  Even after all that has happened I certainly wouldn't change what I have experienced.  Thanks again for being such a &#13;
 &#13;
 &#13;
+XML escape characters
+&quot;
+&apos;
+&lt;
+&gt;
+&amp;
+HTML entities
+&rfloor;
+&spades;
+&copy;
+&rarr;
+Decimal entities
+&#01;
+&#13;
+&#453;
+Hex Entities
+&#x01ED;
+&#x020f;
 </content>
 
 </document>

--- a/test/graph/graphSerializer-test.js
+++ b/test/graph/graphSerializer-test.js
@@ -19,6 +19,23 @@ describe('GraphSerializer', function() {
         assert(typeof GraphSerializer.serializeXml === 'function');
     });
 
+    describe('serialization', function() {
+        var graph,
+            filePath = path.join(__dirname, '..', 'fixtures', 'test-doc-with-cr.xml');
+
+        beforeEach(function(done) {
+            GraphParser.parse(fs.createReadStream(filePath)).then(function(aGraph) {
+                graph = aGraph; done();
+            }, console.error);
+        });
+
+        it('should not change pagi content node', function() {
+            var serializedGraph = GraphSerializer.serialize(graph);
+            var original = fs.readFileSync(filePath, {encoding: 'utf8'});
+            assert.equal(serializedGraph, original);
+        });
+    });
+
     testStream.fullList.forEach(function(stream) {
         // if (stream.name !== 'extTokFullSchema') { return; }
         // console.log("GraphSerializer testing stream " + stream.name);

--- a/test/graph/graphSerializer-test.js
+++ b/test/graph/graphSerializer-test.js
@@ -21,7 +21,7 @@ describe('GraphSerializer', function() {
 
     describe('serialization', function() {
         var graph,
-            filePath = path.join(__dirname, '..', 'fixtures', 'test-doc-with-cr.xml');
+            filePath = path.join(__dirname, '..', 'fixtures', 'test-doc-with-xml-entities.xml');
 
         beforeEach(function(done) {
             GraphParser.parse(fs.createReadStream(filePath)).then(function(aGraph) {


### PR DESCRIPTION
Overview
This ticket implements a caching feature that captures the raw content of the pagi content node before it is parsed by the sax parser, and writes the cached version back to the serialized file when we save. This way we are guaranteed that viewing and editing the nodes in the graph is non-destructive to the original text content of the pagi graph.

Testing
Review code, ensure tests pass (by running npm test). The drawback to this implementation is that we can no longer pass the graph parser a generic readable stream, and it must be always be passed a cache stream instead. 
